### PR TITLE
Hides the certificate paths env vars from direct user configuration

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
           value: kubernetes
         - name: TFE_VAULT_DISABLE_MLOCK
           value: "true"
+        - name: TFE_TLS_CERT_FILE
+          value: "{{ .Values.tls.certMountPath }}"
+        - name: TFE_TLS_KEY_FILE
+          value: "{{ .Values.tls.keyMountPath }}"
         {{- if .Values.tls.caCertData }}
         - name: TFE_TLS_CA_BUNDLE_FILE
           value: /etc/ssl/certs/custom_ca_cert.pem
@@ -57,10 +61,10 @@ spec:
             cpu: {{ .Values.resources.limits.cpu }}
         volumeMounts:
           - name: certificates
-            mountPath: /etc/ssl/private/terraform-enterprise/cert.pem
+            mountPath: {{ .Values.tls.certMountPath }}
             subPath: tls.crt
           - name: certificates
-            mountPath: /etc/ssl/private/terraform-enterprise/key.pem
+            mountPath: {{ .Values.tls.keyMountPath }}
             subPath: tls.key
           {{- if .Values.tls.caCertData }}
           - name: ca-certificates

--- a/values.yaml
+++ b/values.yaml
@@ -27,6 +27,8 @@ tls:
   certificateSecret: terraform-enterprise-certificates
   caCertBaseDir: /etc/ssl/certs
   caCertFileName: custom_ca_certs.pem
+  certMountPath: /etc/ssl/private/terraform-enterprise/cert.pem
+  keyMountPath: /etc/ssl/private/terraform-enterprise/key.pem
   # certData:
   # keyData:
   # caCertData:
@@ -70,8 +72,6 @@ env:
   TFE_IACT_TIME_LIMIT: "60"
   TFE_OPERATIONAL_MODE: "disk"
   TFE_TLS_VERSION: "tls_1_2_tls_1_3"
-  TFE_TLS_CERT_FILE: "/etc/ssl/private/terraform-enterprise/cert.pem"
-  TFE_TLS_KEY_FILE: "/etc/ssl/private/terraform-enterprise/key.pem"
   TFE_VAULT_DISABLE_MLOCK: true
   # TFE_CAPACITY_CONCURRENCY: ""
   # TFE_CAPACITY_CPU: ""


### PR DESCRIPTION
Alpha testing recently pointed out that if the helm chart is managing the certificate data there's no need to allow the user to configure the env vars for the certificate paths.  This change hides that config and references the same setting in multiple places to ensure they do not go out of sync.