### PR TITLE
Adding TFE_HTTP(S)_PORT settings

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
           value: "{{ .Values.tls.certMountPath }}"
         - name: TFE_TLS_KEY_FILE
           value: "{{ .Values.tls.keyMountPath }}"
+        - name: TFE_HTTP_PORT
+          value: "{{ .Values.tfe.privateHttpPort }}"
+        - name: TFE_HTTPS_PORT
+          value: "{{ .Values.tfe.privateHttpsPort }}"
         {{- if .Values.tls.caCertData }}
         - name: TFE_TLS_CA_BUNDLE_FILE
           value: /etc/ssl/certs/custom_ca_cert.pem
@@ -51,7 +55,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /_health_check
-            port: 80
+            port: {{ .Values.tfe.privateHttpPort }}
         resources:
           requests:
             memory: {{ .Values.resources.requests.memory }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: 443
-      targetPort: 443
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.tfe.privateHttpsPort }}
   selector:
     app: terraform-enterprise

--- a/values.yaml
+++ b/values.yaml
@@ -33,6 +33,10 @@ tls:
   # keyData:
   # caCertData:
 
+tfe:
+    privateHttpPort: 8080
+    privateHttpsPort: 8443
+
 nodeSelector: {}
 
 tolerations: []
@@ -63,7 +67,7 @@ ingress:
 
 service:
   type: LoadBalancer # ClusterIP
-
+  port: 443
 
 env:
   TFE_ENCRYPTION_PASSWORD: "SUPERDUPERSECRET"


### PR DESCRIPTION
The non-root changes recently introduced break TFE in kubernetes. This change establishes a default non-low-range port for http and https communication that alleviates this issue