### PR TITLE
remove resources.limits.cpu by default

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -26,7 +26,6 @@ resources: {}
 #    cpu: ""
 #  limits:
 #    memory: ""
-#    cpu: ""
 
 tls:
   certificateSecret: terraform-enterprise-certificates


### PR DESCRIPTION
This PR remove the CPU limit under resources, due to the fact that we don't want CPU to have a limit (to only have requests by default) so that TFE can consume more CPU if it needs to.

https://hashicorp.atlassian.net/browse/TF-5427