### PR TITLE
Add copyright to helm chart and templates

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 apiVersion: v2
 name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,3 +1,8 @@
+{{/*
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,3 +1,8 @@
+{{/*
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
 {{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -1,3 +1,8 @@
+{{/*
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
 apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,3 +1,8 @@
+{{/*
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
 {{- if and .Values.tls.certData .Values.tls.keyData }}
 apiVersion: v1
 kind: Secret

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,3 +1,8 @@
+{{/*
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 # Default values for Terraform Enterprise on Kubernetes.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -63,6 +66,9 @@ tolerations: []
 # deployment to single node services such as Minikube
 # This should be either a multi-line string or YAML matching the PodSpec's affinity field.
 affinity: {}
+#
+## Example:
+#  
 #  affinity: |
 #    podAntiAffinity:
 #      requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This simple PR adds our HashiCorp copyright to all or helm templates and chart.