### PR TITLE
Use image pull policy from values file

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -45,11 +45,10 @@ spec:
       serviceAccountName: {{ .Release.Namespace }}
       initContainers:
         {{ toYaml .Values.initContainers | nindent 8}}
-        {{- end }}
       containers: 
       - name: terraform-enterprise
         image: {{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy:  {{ .Values.image.pullPolicy }}
         env:
         {{- include "helpers.list-env-variables" . | indent 8 }}
         - name: TFE_RUN_PIPELINE_KUBERNETES_NAMESPACE


### PR DESCRIPTION
No Jira. This PR ensures the `image pull policy` from values file is used in deployment.yaml.
Also, an unnecessary "end" was removed as the chart returned the error below when I tried to do a helm debug.

```
✗ helm template --debug .                        
install.go:193: [debug] Original chart version: ""
install.go:210: [debug] CHART PATH: /Users/kosyanyanwu/workspace/terraform-enterprise-helm


Error: parse error at (terraform-enterprise/templates/deployment.yaml:48): unexpected {{end}}
helm.go:84: [debug] parse error at (terraform-enterprise/templates/deployment.yaml:48): unexpected {{end}}
```