### PR TITLE
Update RBAC

### DIFF
--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -29,6 +29,7 @@ rules:
   - jobs
   - pods
   - configmaps
+  - "pods/log"
   verbs:
   - list
   - watch


### PR DESCRIPTION
No Jira.

But "pods/log" needs to be part of the resources in rbac to enable agent pods send logs back to TTW in order to prevent this error:

```sh
{"@level":"error","@message":"error streaming kubernetes pod log request","@module":"task-worker.executor","@timestamp":"2023-05-11T15:42:32.639572Z","error":"pods \"tfe-task-422354f5-2a8d-4136-8dff-33ecb26d2faa-sspc2\" is forbidden: User \"system:serviceaccount:kosy:kosy\" cannot get resource \"pods/log\" in API group \"\" in the namespace \"kosy-agents\"","job name":"tfe-task-422354f5-2a8d-4136-8dff-33ecb26d2faa"}
```