### PR TITLE
Standardizing cacert mount paths in the tfe deployment

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -30,6 +30,10 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "cacert.path" -}}
+{{ .Values.tls.caCertBaseDir }}/{{ .Values.tls.caCertFileName }}
+{{- end }}
+
 {{/*
 Common labels
 */}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           value: "{{ .Values.tfe.privateHttpsPort }}"
         {{- if .Values.tls.caCertData }}
         - name: TFE_TLS_CA_BUNDLE_FILE
-          value: /etc/ssl/certs/custom_ca_cert.pem
+          value: {{ include "cacert.path" . }}
         {{- end }}
         readinessProbe:
           httpGet:
@@ -84,6 +84,6 @@ spec:
             subPath: tls.key
           {{- if .Values.tls.caCertData }}
           - name: ca-certificates
-            mountPath: {{ .Values.tls.caCertBaseDir }}/{{ .Values.tls.caCertFileName }}
+            mountPath: {{ include "cacert.path" . }}
             subPath: {{ .Values.tls.caCertFileName }}
           {{- end }}


### PR DESCRIPTION
This change eliminates the hard pathing to ca certs at `/etc/ssl/certs/custom_ca_cert.pem` and uses a shared define to ensure that the cacert mount path and the path set in `env.TFE_TLS_CA_BUNDLE_FILE` do not diverge. 