### PR TITLE
Synchronizing dev charts with our release charts

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MPL-2.0
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: terraform-enterprise 
+  name: terraform-enterprise
   labels:
     app: terraform-enterprise
 spec:
@@ -45,10 +45,10 @@ spec:
       serviceAccountName: {{ .Release.Namespace }}
       initContainers:
         {{ toYaml .Values.initContainers | nindent 8}}
-      containers: 
+      containers:
       - name: terraform-enterprise
         image: {{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
-        imagePullPolicy:  {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "helpers.list-env-variables" . | indent 8 }}
         - name: TFE_RUN_PIPELINE_KUBERNETES_NAMESPACE
@@ -73,6 +73,7 @@ spec:
           httpGet:
             path: /_health_check
             port: {{ .Values.tfe.privateHttpPort }}
+            scheme: HTTP
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:
@@ -87,3 +88,6 @@ spec:
             mountPath: {{ include "cacert.path" . }}
             subPath: {{ .Values.tls.caCertFileName }}
           {{- end }}
+        ports:
+        - containerPort: {{ .Values.tfe.privateHttpPort }}
+        - containerPort: {{ .Values.tfe.privateHttpsPort }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -7,10 +7,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: terraform-enterprise
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - name: https-port
+      port: {{ .Values.service.port }}
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       targetPort: {{ .Values.tfe.privateHttpsPort }}
   selector:
     app: terraform-enterprise

--- a/values.yaml
+++ b/values.yaml
@@ -16,7 +16,7 @@ image:
  repository: quay.io
  name: hashicorp/terraform-enterprise
  tag: latest
- pullPolicy: IfNotPresent
+ pullPolicy: Always
  pullSecret: terraform-enterprise
 
 pod:
@@ -45,8 +45,8 @@ tls:
   # caCertData:
 
 tfe:
-    privateHttpPort: 8080
-    privateHttpsPort: 8443
+  privateHttpPort: 8080
+  privateHttpsPort: 8443
 
 # nodeSelector labels for server pod assignment, formatted as a multi-line string or YAML map.
 nodeSelector: {}
@@ -143,8 +143,11 @@ ingress:
 
  # Injector service specific configurations
 service:
+  annotations: {}
+    # cloud.google.com/neg: '{"ingress": true}'
   type: LoadBalancer # ClusterIP
   port: 443
+  nodePort: 32443 # if service.type is NodePort value will be set
 
 env:
   TFE_ENCRYPTION_PASSWORD: "SUPERDUPERSECRET"
@@ -154,6 +157,7 @@ env:
   TFE_OPERATIONAL_MODE: "disk"
   TFE_TLS_VERSION: "tls_1_2_tls_1_3"
   TFE_VAULT_DISABLE_MLOCK: true
+  TFE_LICENSE_REPORTING_OPT_OUT: true
   # TFE_CAPACITY_CONCURRENCY: ""
   # TFE_CAPACITY_CPU: ""
   # TFE_CAPACITY_MEMORY: ""


### PR DESCRIPTION
The development chart has drifted by adding:

- Nodeport service customization
- HTTP scheme specification 
- default pull policy change to always to avoid `latest` tag confusion across a node group


This chance synchronizes these updates.