### PR TITLE
remove default configFilePath

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -52,8 +52,8 @@ spec:
         image: {{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         envFrom:
-        {{- if .Values.env.configMaps }}
-          {{- range .Values.env.configMaps }}
+        {{- if .Values.env.configMapRefs }}
+          {{- range .Values.env.configMapRefs }}
           - configMapRef:
               name: {{ .name }}
           {{- end }}
@@ -61,10 +61,6 @@ spec:
           - configMapRef:
               name: terraform-enterprise-env-config
         {{- end }}
-          {{- range .Values.env.configMapRefs }}
-          - configMapRef:
-              name: {{ .name }}
-          {{- end }}
         {{- if .Values.env.secretRefs }}
           {{- range .Values.env.secretRefs }}
           - secretRef:

--- a/values.yaml
+++ b/values.yaml
@@ -149,8 +149,12 @@ service:
   nodePort: 32443 # if service.type is NodePort value will be set
 
 env:
-  configFilePath: env-config.yaml
-  secretsFilePath: env-secrets.yaml
+  # configFilePath: env-config.yaml
+  # secretsFilePath: # env-secrets.yaml
+  # configMapRefs:
+  #   - name:
+  # secretRefs:
+  #    - name:
   secrets: {}
     # TFE_ENCRYPTION_PASSWORD: "SECRET"
     # TFE_DATABASE_PASSWORD: ""
@@ -187,7 +191,4 @@ env:
     # TFE_VAULT_NAMESPACE: ""
     # TFE_VAULT_PATH: ""
     # TFE_VAULT_ROLE_ID: ""
-  configMapRefs: []
-    # - name:
-  secretRefs: []
-    # - name:
+


### PR DESCRIPTION
This pull request removes a conflicting view where the `configFilePath` was a required value but also had a default that changed nothing in the configuration.

Additional fix: there was a double iteration on a property that no longer exists.