### PR TITLE
Add update-helm-charts workflow

### DIFF
--- a/.github/workflows/update-helm-charts-index.yml
+++ b/.github/workflows/update-helm-charts-index.yml
@@ -1,0 +1,39 @@
+name: update-helm-charts-index
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+jobs:
+  update-helm-charts-index:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: verify Chart version matches tag version
+        run: |-
+          git_tag=$(echo "${{ github.ref_name }}" | sed 's/v//g')
+          chart_tag=$(yq '.version' Chart.yaml)
+          if [ "${git_tag}" != "${chart_tag}" ]; then
+            echo "chart version (${chart_tag}) did not match git version (${git_tag})"
+            exit 1
+          fi
+      - name: update helm-charts index
+        id: update
+        env:
+          GH_TOKEN: ${{ secrets.HELM_CHARTS_GITHUB_TOKEN }}
+        run: |-
+          gh workflow run publish-charts.yml \
+            --repo hashicorp/helm-charts \
+            --ref main \
+            -f SOURCE_TAG="${{ github.ref_name }}" \
+            -f SOURCE_REPO="${{ github.repository }}"
+      - name: Send Slack Notification
+        if: ${{ always() }}
+        uses: hashicorp/actions-slack-status@v1
+        with:
+          # Note: we opt not to send a message on cancellation
+          success-message: ":tada: waypoint-helm charts index update triggered successfully. View the <https://github.com/hashicorp/helm-charts/actions/workflows/publish-charts.yml|run>."
+          failure-message: ":red_circle: The waypoint-helm charts index update trigger failed."
+          status: ${{ steps.update.conclusion }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+permissions:
+  contents: read


### PR DESCRIPTION
This PR adds a workflow that is triggered by pushing a new tag (`vx.x.x`), and runs the `publish-charts.yml` in the `hashicorp/helm-chart` repo.