### PR TITLE
v0.1.1 release prep

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.16.0"


### PR DESCRIPTION
This change increments the chart version to 0.1.1 to prepare for the first public release of the terraform-enterprise chart.