### PR TITLE
fix default env config injection

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.16.0"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -52,23 +52,21 @@ spec:
         image: {{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         envFrom:
+          - configMapRef:
+              name: terraform-enterprise-env-config
         {{- if .Values.env.configMapRefs }}
           {{- range .Values.env.configMapRefs }}
           - configMapRef:
               name: {{ .name }}
           {{- end }}
-        {{- else }}
-          - configMapRef:
-              name: terraform-enterprise-env-config
         {{- end }}
+          - secretRef:
+              name: terraform-enterprise-env-secrets
         {{- if .Values.env.secretRefs }}
           {{- range .Values.env.secretRefs }}
           - secretRef:
               name: {{ .name }}
           {{- end }}
-        {{- else }}
-          - secretRef:
-              name: terraform-enterprise-env-secrets
         {{- end }}
         readinessProbe:
           httpGet:


### PR DESCRIPTION
There is an issue in the chart, where if any config map is provided via the `.Values.environment.configMapRefs` or secrets, then the required default configuration is not considered. This pull request makes such default configuration always part of the deployment.