### PR TITLE
Adds configuration and support for TFE metrics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,3 +32,25 @@ tls:
 ```
 
 The contents of this file are appended to the terraform-enterprise container CA certificates file. Agent images are then instantiated with the entirety of this combined CA certificate file fully replacing the native container operating system's CA certificate file. This allows tfc-agent to communicate with any dependent services or endpoints that might signed with your private certificate authorities, including Terraform Enterprise itself.
+
+## Metrics
+
+Terraform Enterprise exposes metrics in json or Prometheus format. This chart exposes a value at `.Values.tfe.metrics.enable` that exposes the container ports for the metrics service, configures Terraform Enterprise to launch the metrics service, and annotates the Terraform Enterprise pods with common annotations required for Prometheus discovery and automated metrics scraping. More information about metrics can be found [in the Terraform Enterprise Metrics documentation](https://developer.hashicorp.com/terraform/enterprise/admin/infrastructure/monitoring).
+
+Prometheus scrape annotations
+```
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    annotations:
+      prometheus.io/path: /metrics
+      prometheus.io/port: "9090"
+      prometheus.io/scrape: "true"
+    creationTimestamp: "2023-09-01T15:42:32Z"
+    generateName: terraform-enterprise-546db68fcd-
+    labels:
+      app: terraform-enterprise
+...
+```

--- a/templates/config-map.yaml
+++ b/templates/config-map.yaml
@@ -19,6 +19,11 @@ data:
   {{- if .Values.tls.caCertData }}
   TFE_TLS_CA_BUNDLE_FILE: {{ include "cacert.path" . }}
   {{- end }}
+  {{- if .Values.tfe.metrics.enable }}
+  TFE_METRICS_ENABLE: {{ include ".Values.tfe.metrics.enable" . }}
+  TFE_METRICS_HTTP_PORT: {{ include ".Values.tfe.metrics.httpPort" . }}
+  TFE_METRICS_HTTPS_PORT: {{ include ".Values.tfe.metrics.httpsPort" . }}
+  {{- end }}
 {{- if .Values.env.configFilePath }}
 {{ .Files.Get .Values.env.configFilePath | indent 2 }}
 {{- end }}

--- a/templates/config-map.yaml
+++ b/templates/config-map.yaml
@@ -20,9 +20,9 @@ data:
   TFE_TLS_CA_BUNDLE_FILE: {{ include "cacert.path" . }}
   {{- end }}
   {{- if .Values.tfe.metrics.enable }}
-  TFE_METRICS_ENABLE: {{ include ".Values.tfe.metrics.enable" . }}
-  TFE_METRICS_HTTP_PORT: {{ include ".Values.tfe.metrics.httpPort" . }}
-  TFE_METRICS_HTTPS_PORT: {{ include ".Values.tfe.metrics.httpsPort" . }}
+  TFE_METRICS_ENABLE: "{{ .Values.tfe.metrics.enable }}"
+  TFE_METRICS_HTTP_PORT: "{{ .Values.tfe.metrics.httpPort }}"
+  TFE_METRICS_HTTPS_PORT: "{{ .Values.tfe.metrics.httpsPort }}"
   {{- end }}
 {{- if .Values.env.configFilePath }}
 {{ .Files.Get .Values.env.configFilePath | indent 2 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -17,9 +17,14 @@ spec:
   template:
     metadata:
       annotations:
-    {{- if .Values.pod.annotations }}
-    {{ toYaml .Values.pod.annotations | indent 8 }}
-    {{ end }}
+        {{- if .Values.pod.annotations }}
+        {{ toYaml .Values.pod.annotations | indent 8 }}
+        {{ end }}
+        {{- if .Values.tfe.metrics.enable }}
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "{{ .Values.tfe.metrics.httpPort }}"
+        prometheus.io/scrape: "true"
+        {{- end }}
       labels:
         app: terraform-enterprise
     spec:
@@ -90,3 +95,7 @@ spec:
         ports:
         - containerPort: {{ .Values.tfe.privateHttpPort }}
         - containerPort: {{ .Values.tfe.privateHttpsPort }}
+        {{- if .Values.tfe.metrics.enable }}
+        - containerPort: {{.Values.tfe.metrics.httpPort}}
+        - containerPort: {{.Values.tfe.metrics.httpsPort}}
+        {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -44,6 +44,10 @@ tls:
   # caCertData:
 
 tfe:
+  metrics:
+    enable: false
+    httpPort: 9090
+    httpsPort: 9091
   privateHttpPort: 8080
   privateHttpsPort: 8443
 


### PR DESCRIPTION
# Background

This change adds support for TFE metrics by:

- Adding a feature toggle value
- Exposing the metrics container ports
- Setting the environment variables in TFE to toggle on and configure TFE metrics
- Setting the pod annotations common to Kubernetes environment prometheus metric discovery

This change does not:

- Establish or promote an opinion on how a user should scrape the metrics
- Expose these ports as a service:  A user that needs to do so can build a service outside the scope of the chart


This change was tested by spinning up a metrics enabled configuration, a valid prometheus configuration following [this tutorial](https://devopscube.com/setup-prometheus-monitoring-on-kubernetes/) and observing logged TFE metrics:
<img width="1728" alt="image" src="https://github.com/hashicorp/terraform-enterprise-helm/assets/2170651/c54139ae-4661-4619-ac8a-5aabe48de0f3">
