### PR TITLE
Support annotations on the service account

### DIFF
--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -9,6 +9,10 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: Namespace

--- a/values.yaml
+++ b/values.yaml
@@ -18,6 +18,9 @@ image:
  tag: <vYYYYMM-#>
  pullPolicy: Always
 
+serviceAccount:
+  annotations: {}
+
 pod:
 # Configure pod annotations
   annotations: {}


### PR DESCRIPTION
I encountered the same problem as #44. We are using GKE with Workload Identity to facilitate most of the authentication pieces so there's fewer passwords involved in the setup but I'm having to modify the service account the chart is creating to add the annotation. 