### PR TITLE
Fix error in injecting `pod.annotations`

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -19,8 +19,8 @@ spec:
     metadata:
       annotations:
         {{- if .Values.pod.annotations }}
-        {{ toYaml .Values.pod.annotations | indent 8 }}
-        {{ end }}
+        {{- toYaml .Values.pod.annotations | nindent 8 }}
+        {{- end }}
         {{- if .Values.tfe.metrics.enable }}
         prometheus.io/path: "/metrics"
         prometheus.io/port: "{{ .Values.tfe.metrics.httpPort }}"


### PR DESCRIPTION
Using `indent` on an already indented line would add double-indent for the first pod annotation thus rendering whole manifest invalid.

Correct function is `nindent`.