### PR TITLE
Adds support for passing in container securityContext configuration from values.

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
         image: {{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
-        {{- toYaml .Values.pod.securityContext | nindent 10 }}
+        {{- toYaml .Values.container.securityContext | nindent 10 }}
         envFrom:
           - configMapRef:
               name: terraform-enterprise-env-config

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
       - name: terraform-enterprise
         image: {{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+        {{- toYaml .Values.pod.securityContext | nindent 10 }}
         envFrom:
           - configMapRef:
               name: terraform-enterprise-env-config

--- a/values.yaml
+++ b/values.yaml
@@ -175,7 +175,6 @@ env:
     # TFE_LICENSE: ""
   variables: {}
     # TFE_HOSTNAME: ""
-
     # TFE_CAPACITY_CONCURRENCY: ""
     # TFE_CAPACITY_CPU: ""
     # TFE_CAPACITY_MEMORY: ""

--- a/values.yaml
+++ b/values.yaml
@@ -24,6 +24,7 @@ serviceAccount:
 pod:
 # Configure pod annotations
   annotations: {}
+container:
 # Configure pod specific security context settings
   securityContext: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -24,6 +24,8 @@ serviceAccount:
 pod:
 # Configure pod annotations
   annotations: {}
+# Configure pod specific security context settings
+  securityContext: {}
 
 # Resource limits are not set by default, to give the user the ability to set specific resource limits.
 # If you do want to specify resource limits, uncomment the following lines and adjust them as necessary.
@@ -173,6 +175,7 @@ env:
     # TFE_LICENSE: ""
   variables: {}
     # TFE_HOSTNAME: ""
+
     # TFE_CAPACITY_CONCURRENCY: ""
     # TFE_CAPACITY_CPU: ""
     # TFE_CAPACITY_MEMORY: ""


### PR DESCRIPTION
This change introduces a pod.securityContext hash in the chart values. This is rendered into the Terraform Enterprise deployment container spec to allow chart consumers to customize container level security.

This change has been tested via smoke test on a deployed instance.