### PR TITLE
Add the ability to set typologySpreadConstraints

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -100,6 +100,18 @@ affinity: {}
 #                - bar
 #          topologyKey: "kubernetes.io/hostname"
 
+# Topology Spread Constraints
+# This should be either a multi-line string or YAML matching the PodSpec's typologySpreadConstraints field.
+topologySpreadConstraints: []
+
+## Example:
+#  - maxSkew: 1
+#    topologyKey: topology.kubernetes.io/zone
+#    whenUnsatisfiable: DoNotSchedule
+#    labelSelector:
+#      matchLabels:
+#        app: terraform-enterprise
+
 # Security context for the deployment template.
 # The deployment securityContext is not set by default.
 #This should be a YAML map corresponding to a


### PR DESCRIPTION
This PR adds the ability to set the deployment's podSpec's typologySpreadConstraints. This is useful when you hit the limits of simple anti-affinity to achieve things like balancing replicas across availability zones of a multi-AZ cluster.