### PR TITLE
Add a configmap checksum annotation to trigger redeployments

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/env-config: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- if .Values.pod.annotations }}
         {{ toYaml .Values.pod.annotations | indent 8 }}
         {{ end }}


### PR DESCRIPTION
This PR suggests the addition of annotations on the deployment's pods that tracks changes in the configmap and secrets. This would allow a rolling-deploy to be automatically triggered when an environment variable or secret is changed.

This is actually a [recommended recipe](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments) from the maintainers of Helm.