### PR TITLE
Separate serviceAccount and agent CRs, and extend metadata

### DIFF
--- a/templates/agents-namespace.yaml
+++ b/templates/agents-namespace.yaml
@@ -1,0 +1,20 @@
+{{/*
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- if .Values.agents.namespace.enabled }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}-agents
+  {{- with .Values.agents.namespace.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.agents.namespace.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -50,7 +50,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ .Release.Namespace }}
+      {{- end }}
       initContainers:
         {{ toYaml .Values.initContainers | nindent 8}}
       containers:

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -3,27 +3,21 @@ Copyright (c) HashiCorp, Inc.
 SPDX-License-Identifier: MPL-2.0
 */}}
 
-apiVersion: v1
-automountServiceAccountToken: true
-kind: ServiceAccount
-metadata:
-  name: {{ .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}
-  {{- if .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
-  {{- end }}
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Release.Namespace }}-agents
+{{- if .Values.agents.rbac.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Release.Namespace }}
   namespace: {{ .Release.Namespace }}-agents
+  {{- with .Values.agents.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.agents.rbac.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups:
   - ""
@@ -47,6 +41,14 @@ kind: RoleBinding
 metadata:
   name: {{ .Release.Namespace }}-agents
   namespace: {{ .Release.Namespace }}-agents
+  {{- with .Values.agents.rbac.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.agents.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -55,3 +57,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/templates/service-account.yaml
+++ b/templates/service-account.yaml
@@ -1,0 +1,22 @@
+{{/*
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- if .Values.serviceAccount.enabled }}
+---
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+  {{- with .Values.serviceAccount.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -19,7 +19,9 @@ image:
  pullPolicy: Always
 
 serviceAccount:
+  enabled: true
   annotations: {}
+  labels: {}
 
 pod:
 # Configure pod annotations
@@ -210,3 +212,13 @@ env:
     # TFE_VAULT_ROLE_ID: ""
     # TFE_IACT_SUBNETS: ""
     # TFE_IACT_TIME_LIMIT: ""
+
+agents:
+  rbac:
+    enabled: true
+    annotations: {}
+    labels: {}
+  namespace:
+    enabled: true
+    annotations: {}
+    labels: {}


### PR DESCRIPTION
This PR suggests the following:

* Isolates the the agent namespace definition to a dedicated file
* Make the creation of the agent namespace togglable
* Isolates the service-account definition to a dedicated file
* Makes the creation of the service-account namespace togglable
* Ensures that RBACs are the only primitives present in `rbac.yaml`
* Makes the creation of RBAC togglable
* Extends the management of labels and annotations on all the primitives mentioned above

---

This is necessary in our deployments since the creation of namespaces is managed by our CD solution and our Kubernetes API has admission rules regarding labels and annotations.