### PR TITLE
Let `agentWorkerPodTemplate` be in YAML

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,4 +59,5 @@ items:
 
 Terraform Enterprise now supports the inclusion of a custom pod template via `agentWorkerPodTemplate` in the Values file.
 With this, you can define your own specifications for the creation of the agent worker pods.
-The custom pod template must be a valid `corev1.PodTemplateSpec` and should be provided in JSON format.
+The custom pod template must be a valid `corev1.PodTemplateSpec` and should be provided in YAML format. The `PodTemplateSpec` is
+documented at <https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec>.

--- a/templates/config-map.yaml
+++ b/templates/config-map.yaml
@@ -12,7 +12,7 @@ data:
   TFE_RUN_PIPELINE_DRIVER: kubernetes
   TFE_RUN_PIPELINE_KUBERNETES_NAMESPACE: {{ .Release.Namespace }}-agents
   {{- if .Values.agentWorkerPodTemplate }}
-  TFE_RUN_PIPELINE_KUBERNETES_POD_TEMPLATE: {{ .Values.agentWorkerPodTemplate | b64enc }}
+  TFE_RUN_PIPELINE_KUBERNETES_POD_TEMPLATE: {{ .Values.agentWorkerPodTemplate | mustToJson | b64enc }}
   {{- end }}
   TFE_VAULT_DISABLE_MLOCK: "true"
   TFE_HTTP_PORT: "{{ .Values.tfe.privateHttpPort }}"

--- a/values.yaml
+++ b/values.yaml
@@ -161,12 +161,11 @@ service:
 # Custom pod template to define your own specifications for the creation of the agent worker pods.
 # This should be YAML representing a valid corev1.PodTemplateSpec. This format is documented
 # at https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec.
-# For example:
-# metadata: {},
-# spec:
-#   containers: [],
-#   nodeSelector: {}
 agentWorkerPodTemplate: {}
+  # metadata: {}
+  # spec:
+  #   containers: []
+  #   nodeSelector: {}
 
 env:
   # configFilePath: env-config.yaml

--- a/values.yaml
+++ b/values.yaml
@@ -159,7 +159,8 @@ service:
   nodePort: 32443 # if service.type is NodePort value will be set
 
 # Custom pod template to define your own specifications for the creation of the agent worker pods.
-# This should be a JSON string representing a valid corev1.PodTemplateSpec.
+# This should be a JSON string representing a valid corev1.PodTemplateSpec. This format is documented
+# at https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec).
 # For example:
 # {
 #   "metadata": {},

--- a/values.yaml
+++ b/values.yaml
@@ -159,17 +159,14 @@ service:
   nodePort: 32443 # if service.type is NodePort value will be set
 
 # Custom pod template to define your own specifications for the creation of the agent worker pods.
-# This should be a JSON string representing a valid corev1.PodTemplateSpec. This format is documented
-# at https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec).
+# This should be YAML representing a valid corev1.PodTemplateSpec. This format is documented
+# at https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec.
 # For example:
-# {
-#   "metadata": {},
-#   "spec": {
-#     "containers": [],
-#     "nodeSelector": {}
-#   }
-# }
-agentWorkerPodTemplate: ""
+# metadata: {},
+# spec:
+#   containers: [],
+#   nodeSelector: {}
+agentWorkerPodTemplate: {}
 
 env:
   # configFilePath: env-config.yaml


### PR DESCRIPTION
Kubernetes users are typically going to be more comfortable with a YAML format for pod specs, so this change modifies the usage of the `agentWorkerPodTemplate` to convert the YAML to JSON (before it finally gets expanded to base64 for the environment variable) using Helm's `mustToJSON` function. Because the value is taken to JSON whitespace is minified by the JSON converter and the final base64 encoding of the environment variable preserves any whitespace.

This can be tested and validated with `helm template tfe . | grep TFE_RUN_PIPELINE_KUBERNETES_POD_TEMPLATE | awk '{print $2}' | base64 -d` with the `values.yaml`'s `agentWorkerPodTemplate` modified .

This PR also links to the pod spec docs in the `values.yaml` comment as well as the documentation.