### PR TITLE
Add LoadBalancerIP

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -14,6 +14,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - name: https-port
       port: {{ .Values.service.port }}

--- a/values.yaml
+++ b/values.yaml
@@ -157,6 +157,7 @@ service:
   type: LoadBalancer # ClusterIP
   port: 443
   nodePort: 32443 # if service.type is NodePort value will be set
+  loadBalancerIP: null # if the service.type is LoadBalancer, this can optionally be set
 
 env:
   # configFilePath: env-config.yaml


### PR DESCRIPTION
# Summary
Extend the chart with a loadBalancerIP that gets optionally set. 

# How was this tested? 

(1) I first deployed the helm chart without any changes, verifying that the `null` default value works fine. 
(2) I then deployed the helm again, this time with an IP set, and verified that the IP is used for the load balancer, see below 

```
❯ kubectl describe service terraform-enterprise -n nikolasriebletest
Name:                     terraform-enterprise
Namespace:                nikolasriebletest
Labels:                   app.kubernetes.io/managed-by=Helm
Annotations:              cloud.google.com/neg: {"ingress":true}
                          meta.helm.sh/release-name: terraform-enterprise
                          meta.helm.sh/release-namespace: nikolasriebletest
Selector:                 app=terraform-enterprise
Type:                     LoadBalancer
IP Family Policy:         SingleStack
IP Families:              IPv4
IP:                       10.232.7.3
IPs:                      10.232.7.3
IP:                       34.75.137.190
LoadBalancer Ingress:     34.75.137.190
Port:                     https-port  443/TCP
TargetPort:               8443/TCP
NodePort:                 https-port  30430/TCP
Endpoints:                
Session Affinity:         None
External Traffic Policy:  Cluster
Events:
  Type    Reason                Age                    From                Message
  ----    ------                ----                   ----                -------
  Normal  EnsuringLoadBalancer  6m52s (x2 over 8m28s)  service-controller  Ensuring load balancer
  Normal  EnsuredLoadBalancer   6m51s (x2 over 7m59s)  service-controller  Ensured load balancer
```