### PR TITLE
Add openshift support

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -97,3 +97,19 @@ and base64 encodes the value from the key-value pair.
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define helper to conditionally add securityContext to agentWorkerPodTemplate.
+It does not output anything if agentWorkerPodTemplate is empty and OpenShift is not enabled.
+*/}}
+{{- define "k8s.addSecurityContext" -}}
+{{- if or .Values.agentWorkerPodTemplate .Values.openshift.enabled }}
+  {{- $defaultSecurityContext := dict "seccompProfile" (dict "type" "RuntimeDefault") "allowPrivilegeEscalation" false "capabilities" (dict "drop" (list "ALL")) "runAsNonRoot" true }}
+  {{- if and .Values.openshift.enabled (not (hasKey .Values.agentWorkerPodTemplate "securityContext")) }}
+    {{- $securityContextAdded := set .Values.agentWorkerPodTemplate "securityContext" $defaultSecurityContext }}
+    {{- $securityContextAdded | toJson | b64enc }}
+  {{- else }}
+    {{- .Values.agentWorkerPodTemplate | toJson | b64enc }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/templates/config-map.yaml
+++ b/templates/config-map.yaml
@@ -15,7 +15,7 @@ data:
   TFE_RUN_PIPELINE_KUBERNETES_POD_TEMPLATE: {{ .Values.agentWorkerPodTemplate | mustToJson | b64enc }}
   {{- end }}
   {{- if .Values.openshift.enabled }}
-  TFE_RUN_PIPELINE_KUBERNETES_OPEN_SHIFT_ENABLED: true
+  TFE_RUN_PIPELINE_KUBERNETES_OPEN_SHIFT_ENABLED: "true"
   {{- end }}
   TFE_VAULT_DISABLE_MLOCK: "true"
   TFE_HTTP_PORT: "{{ .Values.tfe.privateHttpPort }}"

--- a/templates/config-map.yaml
+++ b/templates/config-map.yaml
@@ -14,6 +14,9 @@ data:
   {{- if .Values.agentWorkerPodTemplate }}
   TFE_RUN_PIPELINE_KUBERNETES_POD_TEMPLATE: {{ .Values.agentWorkerPodTemplate | mustToJson | b64enc }}
   {{- end }}
+  {{- if .Values.openshift.enabled }}
+  TFE_RUN_PIPELINE_KUBERNETES_OPEN_SHIFT_ENABLED: true
+  {{- end }}
   TFE_VAULT_DISABLE_MLOCK: "true"
   TFE_HTTP_PORT: "{{ .Values.tfe.privateHttpPort }}"
   TFE_HTTPS_PORT: "{{ .Values.tfe.privateHttpsPort }}"

--- a/templates/config-map.yaml
+++ b/templates/config-map.yaml
@@ -11,8 +11,8 @@ data:
   {{- include "helpers.list-env-variables" . | indent 2 }}
   TFE_RUN_PIPELINE_DRIVER: kubernetes
   TFE_RUN_PIPELINE_KUBERNETES_NAMESPACE: {{ .Release.Namespace }}-agents
-  {{- if .Values.agentWorkerPodTemplate }}
-  TFE_RUN_PIPELINE_KUBERNETES_POD_TEMPLATE: {{ .Values.agentWorkerPodTemplate | mustToJson | b64enc }}
+  {{- if or .Values.agentWorkerPodTemplate .Values.openshift.enabled }}
+  TFE_RUN_PIPELINE_KUBERNETES_POD_TEMPLATE: {{ include "k8s.addSecurityContext" . }}
   {{- end }}
   {{- if .Values.openshift.enabled }}
   TFE_RUN_PIPELINE_KUBERNETES_OPEN_SHIFT_ENABLED: "true"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -36,7 +36,17 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       securityContext:
+        {{- if and .Values.openshift.enabled (not .Values.securityContext) }}
+        seccompProfile:
+          type: RuntimeDefault
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: true
+        {{- else }}
         {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- end }}
       volumes:
         - name: certificates
           secret:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -36,17 +36,7 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       securityContext:
-        {{- if and .Values.openshift.enabled (not .Values.securityContext) }}
-        seccompProfile:
-          type: RuntimeDefault
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-            - ALL
-        runAsNonRoot: true
-        {{- else }}
         {{- toYaml .Values.securityContext | nindent 8 }}
-        {{- end }}
       volumes:
         - name: certificates
           secret:
@@ -68,7 +58,17 @@ spec:
         image: {{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
+        {{- if and .Values.openshift.enabled (not .Values.container.securityContext) }}
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+        {{- else }}
         {{- toYaml .Values.container.securityContext | nindent 10 }}
+        {{- end }}
         envFrom:
           - configMapRef:
               name: terraform-enterprise-env-config

--- a/values.yaml
+++ b/values.yaml
@@ -168,6 +168,11 @@ agentWorkerPodTemplate: {}
   #   containers: []
   #   nodeSelector: {}
 
+# Configuration for running this Helm chart on Red Hat OpenShift platform.
+openshift:
+  # If true, the Helm chart will create necessary configuration for running its components on OpenShift.
+  enabled: false
+
 env:
   # configFilePath: env-config.yaml
   # secretsFilePath: # env-secrets.yaml


### PR DESCRIPTION
[Jira](https://hashicorp.atlassian.net/browse/TF-14898)

This PR adds support for openshift on the helm chart.

If `Values.openshift.enabled` is `true`, `TFE_RUN_PIPELINE_KUBERNETES_OPEN_SHIFT_ENABLED` is set to `true` on the configmap.
If `Values.container.securityContext` is not set when openshift is enabled, then it gets set on the deployment file.
![Screenshot 2024-05-21 at 1 26 45 PM](https://github.com/hashicorp/terraform-enterprise-helm/assets/10073270/9b7f8ce5-1143-41f7-913e-cca46b856af7)

If `Values.agentWorkerPodTemplate.securityContext` is not set when openshift is enabled, then `TFE_RUN_PIPELINE_KUBERNETES_POD_TEMPLATE` gets set with the security context on the configmap.
![Screenshot 2024-05-21 at 1 27 08 PM](https://github.com/hashicorp/terraform-enterprise-helm/assets/10073270/086de9b7-fb63-4e21-8d12-a8c764752394)
![Screenshot 2024-05-21 at 1 27 33 PM](https://github.com/hashicorp/terraform-enterprise-helm/assets/10073270/47f0351f-ee63-468f-9e34-5bd3270dd739)

If `Values.agentWorkerPodTemplate` was set but no `securityContext` when openshift is enabled, then `TFE_RUN_PIPELINE_KUBERNETES_POD_TEMPLATE` still gets set with the value of agentWorkerPodTemplate including security context on the configmap.
![Screenshot 2024-05-21 at 1 40 17 PM](https://github.com/hashicorp/terraform-enterprise-helm/assets/10073270/61aeffdd-e67a-49b9-9a62-8cdebb4658fd)
![Screenshot 2024-05-21 at 2 04 15 PM](https://github.com/hashicorp/terraform-enterprise-helm/assets/10073270/23c3b409-8938-448b-b45a-fd68f2015b99)

![Screenshot 2024-05-21 at 2 04 31 PM](https://github.com/hashicorp/terraform-enterprise-helm/assets/10073270/3a50f028-da8e-443e-bdfb-1b10fb4709b8)
