### PR TITLE
Add option to automatically roll deployment if the env vars or env secrets change

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -97,3 +97,17 @@ and base64 encodes the value from the key-value pair.
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generates a SHA-256 sum of concatenated env vars ConfigMap contents and env secrets.
+*/}}
+{{- define "helpers.env-checksum" }}
+{{- $env_vars := include (print $.Template.BasePath "/config-map.yaml") . -}}
+{{- if .Values.env.secretsFilePath }}
+{{- $env_secrets := print "%s%s" (include "helpers.list-env-secrets" .) (include "helpers.enc-b64-secrets-file" .) -}}
+{{- print "%s%s" $env_vars $env_secrets | sha256sum }}
+{{- else }}
+{{- $env_secrets := include "helpers.list-env-secrets" . -}}
+{{- print "%s%s" $env_vars $env_secrets | sha256sum }}
+{{- end }}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         prometheus.io/port: "{{ .Values.tfe.metrics.httpPort }}"
         prometheus.io/scrape: "true"
         {{- end }}
+        {{- if .Values.env.autoRollDeployment.enabled }}
+        checksum/env: {{- include "helpers.env-checksum" . }}
+        {{- end }}
       labels:
         app: terraform-enterprise
     spec:

--- a/values.yaml
+++ b/values.yaml
@@ -220,3 +220,10 @@ env:
     # TFE_VAULT_ROLE_ID: ""
     # TFE_IACT_SUBNETS: ""
     # TFE_IACT_TIME_LIMIT: ""
+
+  # Automatically roll deployment if env vars or env secrets change by adding
+  # the checksum of env vars and env secrets as annotation to the deployment:
+  # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+  # Please note: this doesn't work with env.configMapRefs or env.secretRefs
+  autoRollDeployment:
+    enabled: false


### PR DESCRIPTION
Adds an option to automatically roll the deployment if env vars or env secrets change by adding the checksum of env vars and env secrets as annotation to the deployment.
Implements a known Helm trick: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments