### PR TITLE
Comment update on using secrets

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -41,7 +41,8 @@ resources:
 # TLS for end-to-end encrypted transport
 # Including secrets in Helm charts can expose sensitive data if the charts are 
 # stored in a version control system like Git, where they might be accessible 
-# to unauthorized users. The values given below are for testing purposes only.
+# to unauthorized users. It is recommended to manage secrets through a secure 
+# secrets management system. The values given below are for testing purposes only.
 tls:
   certificateSecret: terraform-enterprise-certificates
   caCertBaseDir: /etc/ssl/certs

--- a/values.yaml
+++ b/values.yaml
@@ -183,7 +183,6 @@ env:
   #   - name:
   # secretRefs:
   #    - name:
-
   secrets: {}
     # TFE_ENCRYPTION_PASSWORD: "SECRET"
     # TFE_DATABASE_PASSWORD: ""

--- a/values.yaml
+++ b/values.yaml
@@ -39,6 +39,9 @@ resources:
   #   cpu: ""
 
 # TLS for end-to-end encrypted transport
+# Including secrets in Helm charts can expose sensitive data if the charts are 
+# stored in a version control system like Git, where they might be accessible 
+# to unauthorized users. The values given below are for testing purposes only.
 tls:
   certificateSecret: terraform-enterprise-certificates
   caCertBaseDir: /etc/ssl/certs
@@ -180,6 +183,7 @@ env:
   #   - name:
   # secretRefs:
   #    - name:
+
   secrets: {}
     # TFE_ENCRYPTION_PASSWORD: "SECRET"
     # TFE_DATABASE_PASSWORD: ""


### PR DESCRIPTION
This PR adds comment about using secrets directly on helm chart. 

Link to [JIRA](https://hashicorp.atlassian.net/browse/TF-11917)

Customers should not be encouraged to store secrets directly in helm charts so that they do not take this as guidance from HashiCorp and become exposed to security risk because of it.