### PR TITLE
fix(service): add appProtocol

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -24,5 +24,6 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
       targetPort: {{ .Values.tfe.privateHttpsPort }}
+      appProtocol: https
   selector:
     app: terraform-enterprise


### PR DESCRIPTION
Since `appProtocol` is mandatory to use new GatewayAPI feature, I propose to add this field to the service managed by TFE Helm