### PR TITLE
Add optional labels to the server deployment

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -30,8 +30,8 @@ spec:
         {{- end }}
       labels:
         app: terraform-enterprise
-        {{- if .Values.pod.extraLabels }}
-        {{- toYaml .Values.pod.extraLabels | nindent 8 }}
+        {{- if .Values.pod.labels }}
+        {{- toYaml .Values.pod.labels | nindent 8 }}
         {{- end }}
     spec:
       nodeSelector:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         {{- end }}
       labels:
         app: terraform-enterprise
+        {{- if .Values.pod.extraLabels }}
+        {{- toYaml .Values.pod.extraLabels | nindent 8 }}
+        {{- end }}
     spec:
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -26,7 +26,7 @@ serviceAccount:
 pod:
 # Configure pod annotations
   annotations: {}
-  extraLabels: {}
+  labels: {}
 container:
 # Configure pod specific security context settings
   securityContext: {}

--- a/values.yaml
+++ b/values.yaml
@@ -26,6 +26,7 @@ serviceAccount:
 pod:
 # Configure pod annotations
   annotations: {}
+  extraLabels: {}
 container:
 # Configure pod specific security context settings
   securityContext: {}


### PR DESCRIPTION
Some utilization and billing solutions require labels be set on billable resources in kubernetes to properly account for usage.

To enable this, proposing to add an optional value of extraLabels to the deployment resource for the pod template.