### PR TITLE
Add the min appVersion to the helm chart.

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -7,4 +7,4 @@ kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
 version: 1.3.0
-appVersion: "1.16.0"
+appVersion: "v202406-1"


### PR DESCRIPTION
A customer requested the helm chart appVersion be set appropriately, so this change sets the associated minimum TFE version for the latest helm chart. 

Internal tracking - [IPL-6821](https://hashicorp.atlassian.net/browse/IPL-6821) 

[IPL-6821]: https://hashicorp.atlassian.net/browse/IPL-6821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ