### PR TITLE
allow the deployment's strategy to be specified

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
   selector:
     matchLabels:
       app: terraform-enterprise
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/values.yaml
+++ b/values.yaml
@@ -30,6 +30,14 @@ container:
 # Configure pod specific security context settings
   securityContext: {}
 
+# The deployment's strategy is not set by default. This should be a YAML map corresponding to a 
+# Kubernetes [DeploymentStrategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#deploymentstrategy-v1-apps) object.
+# strategy:
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxSurge: 1
+#     maxUnavailable: 0
+
 # Resource limits are not set by default, to give the user the ability to set specific resource limits.
 # If you do want to specify resource limits, uncomment the following lines and adjust them as necessary.
 resources:


### PR DESCRIPTION
TFE support ticket #156794 was looking for a way to configure the rolling update deployment strategy of their TFE deployment. Currently, the Helm chart does not specify any deployment strategy and instead uses the K8S defaults. This change does not change the default output and instead opts to allow the user to optionally provide any overrides.

Testing:

- [x] Template the chart without any changes to verify default output has not changed: `helm template tfe .`
- [x] Template with a `Recreate` strategy: `helm template tfe . --set strategy.type=Recreate`
- [x] Template with a `RollingUpdate` strategy, also configuring the unavailable and surge limits: `helm template tfe . --set strategy.type=RollingUpdate --set strategy.rollingUpdate.maxUnavailable=2 --set strategy.rollingUpdate.maxSurge=2`