### PR TITLE
feat: optional kubeconfig support - enable runAsNonRoot

### DIFF
--- a/templates/config-map.yaml
+++ b/templates/config-map.yaml
@@ -14,6 +14,9 @@ data:
   {{- if or .Values.agentWorkerPodTemplate .Values.openshift.enabled }}
   TFE_RUN_PIPELINE_KUBERNETES_POD_TEMPLATE: {{ include "k8s.addSecurityContext" . }}
   {{- end }}
+  {{- if .Values.kubeconfig }}
+  TFE_RUN_PIPELINE_KUBERNETES_KUBECONFIG_PATH: /etc/kubernetes/kubeconfig
+  {{- end }}
   {{- if .Values.openshift.enabled }}
   TFE_RUN_PIPELINE_KUBERNETES_OPEN_SHIFT_ENABLED: "true"
   {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -59,6 +59,11 @@ spec:
           secret:
             secretName: terraform-enterprise-ca-certificates
         {{- end }}
+        {{- if .Values.kubeconfig}}
+        - name: kubeconfig-volume
+          secret:
+            secretName: terraform-enterprise-kubeconfig
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -119,6 +124,12 @@ spec:
           - name: ca-certificates
             mountPath: {{ include "cacert.path" . }}
             subPath: {{ .Values.tls.caCertFileName }}
+          {{- end }}
+          {{- if .Values.kubeconfig}}
+          - name: kubeconfig-volume
+            mountPath: /etc/kubernetes
+            subpath: kubeconfig
+            readOnly: true
           {{- end }}
         ports:
         - containerPort: {{ .Values.tfe.privateHttpPort }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -39,3 +39,21 @@ data:
 {{- if .Values.env.secretsFilePath }}
 {{- include "helpers.enc-b64-secrets-file" . | indent 2 }}
 {{- end }}
+
+{{- if .Values.kubeconfig }}
+{{- $clusterName := .Values.kubeconfig.clusterName }}
+{{- $apiServer := .Values.kubeconfig.apiServer }}
+{{- $caData := .Values.kubeconfig.caData }}
+{{- $token := .Values.kubeconfig.token }}
+{{- $namespace := .Values.kubeconfig.namespace | default "default" }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: terraform-enterprise-kubeconfig
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  kubeconfig: {{ b64enc (printf "apiVersion: v1\nkind: Config\nclusters:\n- cluster:\n    certificate-authority-data: %s\n    server: %s\n  name: %s\ncontexts:\n- context:\n    cluster: %s\n    namespace: %s\n    user: %s\n  name: %s-context\ncurrent-context: %s-context\nusers:\n- name: %s\n  user:\n    token: %s\n" $caData $apiServer $clusterName $clusterName $namespace $clusterName $clusterName $clusterName $clusterName $token) | quote }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -31,7 +31,13 @@ container:
 # Configure pod specific security context settings
   securityContext: {}
 
-# The deployment's strategy is not set by default. This should be a YAML map corresponding to a 
+kubeconfig: {}
+  # clusterName: null
+  # apiServer: null
+  # caData: "<base64-encoded-ca-cert>"
+  # token: "<user-token>"
+
+# The deployment's strategy is not set by default. This should be a YAML map corresponding to a
 # Kubernetes [DeploymentStrategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#deploymentstrategy-v1-apps) object.
 # strategy:
 #   type: RollingUpdate
@@ -50,9 +56,9 @@ resources:
   #   cpu: ""
 
 # TLS for end-to-end encrypted transport
-# Including secrets in Helm charts can expose sensitive data if the charts are 
-# stored in a version control system like Git, where they might be accessible 
-# to unauthorized users. It is recommended to manage secrets through a secure 
+# Including secrets in Helm charts can expose sensitive data if the charts are
+# stored in a version control system like Git, where they might be accessible
+# to unauthorized users. It is recommended to manage secrets through a secure
 # secrets management system. The values given below are for testing purposes only.
 tls:
   certificateSecret: terraform-enterprise-certificates

--- a/values.yaml
+++ b/values.yaml
@@ -32,9 +32,9 @@ container:
   securityContext: {}
 
 kubeconfig: {}
-  # clusterName: null
-  # apiServer: null
-  # caData: "<base64-encoded-ca-cert>"
+  # clusterName: <cluster-name>
+  # apiServer: <cluster-api-server>
+  # caData: "<ca-cert-data>"
   # token: "<user-token>"
 
 # The deployment's strategy is not set by default. This should be a YAML map corresponding to a


### PR DESCRIPTION
When TFE runs with the `securityContext.runAsNonRoot`, TFE needs a way to schedule agent pods to the agents' namespace.

To achieve this, we have added an optional kubeconfig configuration. Setting the kubeconfig for the TFE pod is required to run TFE as non-root.