### PR TITLE
feat: add configurable service account name

### DIFF
--- a/templates/service-account.yaml
+++ b/templates/service-account.yaml
@@ -9,7 +9,11 @@ apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
 metadata:
+  {{- if .Values.serviceAccount.name}}
+  name: {{ .Values.serviceAccount.name }}
+  {{- else }}
   name: {{ .Release.Namespace }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:

--- a/values.yaml
+++ b/values.yaml
@@ -20,6 +20,7 @@ image:
 
 serviceAccount:
   enabled: true
+  name: null
   annotations: {}
   labels: {}
 
@@ -31,7 +32,7 @@ container:
 # Configure pod specific security context settings
   securityContext: {}
 
-# The deployment's strategy is not set by default. This should be a YAML map corresponding to a 
+# The deployment's strategy is not set by default. This should be a YAML map corresponding to a
 # Kubernetes [DeploymentStrategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#deploymentstrategy-v1-apps) object.
 # strategy:
 #   type: RollingUpdate
@@ -50,9 +51,9 @@ resources:
   #   cpu: ""
 
 # TLS for end-to-end encrypted transport
-# Including secrets in Helm charts can expose sensitive data if the charts are 
-# stored in a version control system like Git, where they might be accessible 
-# to unauthorized users. It is recommended to manage secrets through a secure 
+# Including secrets in Helm charts can expose sensitive data if the charts are
+# stored in a version control system like Git, where they might be accessible
+# to unauthorized users. It is recommended to manage secrets through a secure
 # secrets management system. The values given below are for testing purposes only.
 tls:
   certificateSecret: terraform-enterprise-certificates


### PR DESCRIPTION
To support AKS' workload identity, the user must be aware of the service account's name attached to the pod. To enable this, I made the service account name configurable.