### PR TITLE
deployment: use overridden service account name if specified

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -64,7 +64,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.serviceAccount.enabled }}
+      {{- if .Values.serviceAccount.name}}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- else }}
       serviceAccountName: {{ .Release.Namespace }}
+      {{- end }}
       {{- end }}
       initContainers:
         {{ toYaml .Values.initContainers | nindent 8}}


### PR DESCRIPTION
Prior to this patch, if a `serviceAccount.name` is specified, the deployment would always use the namespace name as the name. 

After this patch, the `serviceAccountName` will check for a custom value before defaulting to the namespace

Related: https://github.com/hashicorp/terraform-enterprise-helm/pull/91