### PR TITLE
feat: optional readiness probe configuration

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -107,9 +107,9 @@ spec:
         {{- end }}
         readinessProbe:
           httpGet:
-            path: {{ default /_health_check .values.tfe.readinessProbePath }}
+            path: {{ default "/_health_check" .values.tfe.readinessProbePath }}
             port: {{ .Values.tfe.privateHttpPort }}
-            scheme: {{ default HTTP .values.tfe.readinessProbeScheme }}
+            scheme: {{ default "HTTP" .values.tfe.readinessProbeScheme }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -107,9 +107,9 @@ spec:
         {{- end }}
         readinessProbe:
           httpGet:
-            path: /_health_check
+            path: {{ default /_health_check .values.tfe.readinessProbePath }}
             port: {{ .Values.tfe.privateHttpPort }}
-            scheme: HTTP
+            scheme: {{ default HTTP .values.tfe.readinessProbeScheme }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:


### PR DESCRIPTION
When helm chart deploys `deployment.yaml` template, it will support optionally configuring the readiness probe to different url backends and schemes. This will allow customers to configure it to hit `/_health_check?full` rather than just `/_health_check`.