### PR TITLE
feat: allow the agent namespace to be customized

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -113,3 +113,14 @@ It does not output anything if agentWorkerPodTemplate is empty and OpenShift is 
   {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Obtains the agent namespace as configured
+*/}}
+{{- define "helpers.agent-namespace"}}
+{{- if .Values.agents.namespace.name }}
+{{- .Values.agents.namespace.name }}
+{{- else }}
+{{- .Release.Namespace }}-agents
+{{- end }}
+{{- end }}

--- a/templates/agents-namespace.yaml
+++ b/templates/agents-namespace.yaml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Release.Namespace }}-agents
+  name: {{ include "helpers.agent-namespace" . }}
   {{- with .Values.agents.namespace.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/templates/config-map.yaml
+++ b/templates/config-map.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   {{- include "helpers.list-env-variables" . | indent 2 }}
   TFE_RUN_PIPELINE_DRIVER: kubernetes
-  TFE_RUN_PIPELINE_KUBERNETES_NAMESPACE: {{ .Release.Namespace }}-agents
+  TFE_RUN_PIPELINE_KUBERNETES_NAMESPACE: {{ include "helpers.agent-namespace" . }}
   {{- if or .Values.agentWorkerPodTemplate .Values.openshift.enabled }}
   TFE_RUN_PIPELINE_KUBERNETES_POD_TEMPLATE: {{ include "k8s.addSecurityContext" . }}
   {{- end }}

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Release.Namespace }}
-  namespace: {{ .Release.Namespace }}-agents
+  namespace: {{ include "helpers.agent-namespace" . }}
   {{- with .Values.agents.rbac.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -39,8 +39,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Namespace }}-agents
-  namespace: {{ .Release.Namespace }}-agents
+  name: {{ include "helpers.agent-namespace" . }}
+  namespace: {{ include "helpers.agent-namespace" . }}
   {{- with .Values.agents.rbac.labels }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -260,6 +260,10 @@ agents:
     annotations: {}
     labels: {}
   namespace:
+    # Whether to create a namespace for the agents.
     enabled: true
+    # The name of the agent namespace to create, or the name of the namespace to use if it
+    # already exists. Defaults to the release namespace with the suffix "-agents".
+    name: null
     annotations: {}
     labels: {}


### PR DESCRIPTION
This fixes a customer issue where the agent namespace was hardcoded to `{{.Release.Namespace}}-agents`, even if `.Values.agent.namespace.enabled` was set to false. This change allows the agent namespace to be customized by setting `.Values.agent.namespace.name`.

## Tested templates:

### TFE with a pre-existing namespace called testing-ns:

```bash
helm template tfe . --set agents.namespace.enabled=false --set agents.namespace.name=testing-ns
```

### TFE with a new namespace called testing-ns:

```bash
helm template tfe . --set agents.namespace.enabled=true --set agents.namespace.name=testing-ns
```

### TFE with the default namespace name:

```bash
helm template tfe . --set agents.namespace.enabled=true
```