### PR TITLE
Documents newly added readiness probe settings

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -72,6 +72,9 @@ tfe:
     httpsPort: 9091
   privateHttpPort: 8080
   privateHttpsPort: 8443
+  ## Readiness probe settings customize the terraform-enterprise health check path, eg: to use the full service dependency check
+  # readinessProbePath: "/_health_check?full"
+  # readinessProbeScheme: "HTTP"
 
 # nodeSelector labels for server pod assignment, formatted as a multi-line string or YAML map.
 nodeSelector: {}


### PR DESCRIPTION
#95  introduced new readiness probe configuration options with sensible defaults.  This change documents those settings in the values file.