### PR TITLE
Bug: Helm chart should work without optional fields set

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -107,9 +107,9 @@ spec:
         {{- end }}
         readinessProbe:
           httpGet:
-            path: {{ default "/_health_check" .values.tfe.readinessProbePath }}
+            path: {{ .Values.tfe.readinessProbePath | default "/_health_check" }}
             port: {{ .Values.tfe.privateHttpPort }}
-            scheme: {{ default "HTTP" .values.tfe.readinessProbeScheme }}
+            scheme: {{ .Values.tfe.readinessProbeScheme | default "HTTP"  }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:


### PR DESCRIPTION
While reproducing https://hashicorp.atlassian.net/browse/IPL-7384, I found a separate bug currently on main.

https://github.com/hashicorp/terraform-enterprise-helm/pull/95/files introduced a bug, where the helm chart would require the fields that are intended to be optional. 

Currently on main: 
```
❯ helm template tfe . --dry-run --debug
install.go:218: [debug] Original chart version: ""
install.go:235: [debug] CHART PATH: /Users/niko.rieble/code/terraform-enterprise-helm


Error: template: terraform-enterprise/templates/deployment.yaml:110:53: executing "terraform-enterprise/templates/deployment.yaml" at <.values.tfe.readinessProbePath>: nil pointer evaluating interface {}.tfe
helm.go:84: [debug] template: terraform-enterprise/templates/deployment.yaml:110:53: executing "terraform-enterprise/templates/deployment.yaml" at <.values.tfe.readinessProbePath>: nil pointer evaluating interface {}.tfe
```

With this change: 
```
❯ helm template tfe . --dry-run --debug
install.go:218: [debug] Original chart version: ""
install.go:235: [debug] CHART PATH: /Users/niko.rieble/code/terraform-enterprise-helm

...

        readinessProbe:
          httpGet:
            path: /_health_check
            port: 8080
            scheme: HTTP

...
```

With a value set on this PR: 
```
❯ helm template tfe . --set tfe.readinessProbePath="/custom_path" --dry-run --debug
install.go:218: [debug] Original chart version: ""
install.go:235: [debug] CHART PATH: /Users/niko.rieble/code/terraform-enterprise-helm

...

        readinessProbe:
          httpGet:
            path: /custom_path
            port: 8080
            scheme: HTTP

...
```