### PR TITLE
Chore: Add CI to prevent merging if not valid

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,27 @@
+name: Helm Chart CI
+
+on:
+  pull_request:
+
+jobs:
+  helm_chart_ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Checkout the repository
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Step 2: Set up Helm
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+
+      # Step 3: Lint the Helm chart
+      - name: Lint Helm chart
+        run: |
+          helm lint .
+
+      # Step 4: Render and validate Helm templates
+      - name: Validate rendered Helm templates
+        run: |
+          helm template . | kubeconform --strict

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,7 @@
 name: Helm Chart CI
 
 on:
-  pull_request:
+  push:
 
 jobs:
   helm_chart_ci:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,9 +26,8 @@ jobs:
         run: |
           curl -LO https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz
           tar -xzf kubeconform-linux-amd64.tar.gz
-          sudo mv kubeconform /usr/local/bin/
 
       # Step 5: Render and validate Helm templates
       - name: Validate rendered Helm templates
         run: |
-          helm template . | kubeconform --strict
+          helm template . | ./kubeconform --strict

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,7 +21,14 @@ jobs:
         run: |
           helm lint .
 
-      # Step 4: Render and validate Helm templates
+      # Step 4: Install kubeconform
+      - name: Install kubeconform
+        run: |
+          curl -LO https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz
+          tar -xzf kubeconform-linux-amd64.tar.gz
+          sudo mv kubeconform /usr/local/bin/
+
+      # Step 5: Render and validate Helm templates
       - name: Validate rendered Helm templates
         run: |
           helm template . | kubeconform --strict


### PR DESCRIPTION
## Why

To prevent us from merging any other invalid helm charts in the future, I propose we add a CI check. This check is intended to fail right, since https://github.com/hashicorp/terraform-enterprise-helm/pull/101. 

## What
Using both helm lint and kubeconform provides comprehensive validation for Helm charts. helm lint ensures the chart structure and Helm-specific conventions are correct, catching errors like invalid YAML and template syntax issues. kubeconform complements this by validating the rendered Kubernetes manifests against the Kubernetes API schema, ensuring compatibility with cluster specifications. Together, they help prevent both Helm-specific and Kubernetes-specific issues before deployment.

## Test
I do not need to test the linter, since it already fails on this PR. 
To test kubeconform, I added an invalid property to the deployment.yml 

```
        readinessProbe:
          niko: "test"
```

And so, kubeconform fails:
```
❯ helm template . | kubeconform --strict
stdin - Deployment terraform-enterprise is invalid: problem validating schema. Check JSON formatting: jsonschema: '/spec/template/spec/containers/0/readinessProbe' does not validate with https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/deployment-apps-v1.json#/properties/spec/properties/template/properties/spec/properties/containers/items/properties/readinessProbe/additionalProperties: additionalProperties 'niko' not allowed
```

