### PR TITLE
Bug: Set appProtocol to tcp

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -24,6 +24,6 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
       targetPort: {{ .Values.tfe.privateHttpsPort }}
-      appProtocol: https
+      appProtocol: tcp
   selector:
     app: terraform-enterprise

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -24,6 +24,6 @@ spec:
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
       targetPort: {{ .Values.tfe.privateHttpsPort }}
-      appProtocol: tcp
+      appProtocol: {{ .Values.service.appProtocol }}
   selector:
     app: terraform-enterprise

--- a/values.yaml
+++ b/values.yaml
@@ -184,11 +184,30 @@ ingress:
  # Injector service specific configurations
 service:
   annotations: {}
-    # cloud.google.com/neg: '{"ingress": true}'
-  type: LoadBalancer # ClusterIP
-  port: 443
-  nodePort: 32443 # if service.type is NodePort value will be set
-  loadBalancerIP: null # if the service.type is LoadBalancer, this can optionally be set
+    # Add annotations here for specific cloud provider configurations.
+    # Examples:
+    # - For Google Cloud, use the NEG (Network Endpoint Group) annotation:
+    #   cloud.google.com/neg: '{"ingress": true}'
+    # - For Azure, configure the health probe request path for HTTPS health checks:
+    #   service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/_health_check"
+
+  type: LoadBalancer # The type of service to create. Options: LoadBalancer, ClusterIP, NodePort.
+                     # - LoadBalancer: Exposes the service externally using a cloud provider's load balancer.
+                     # - ClusterIP: Default type; exposes the service only within the cluster.
+                     # - NodePort: Exposes the service on a static port on each cluster node.
+
+  port: 443          # The port exposed by the service (external port).
+
+  nodePort: 32443    # If service.type is NodePort, this sets the external port on cluster nodes.
+                     # Ignored for LoadBalancer and ClusterIP types.
+
+  appProtocol: tcp   # Application protocol for the service.
+                     # - Default is "tcp" for broad compatibility across cloud providers.
+                     # - Set to "https" if Gateway API or Layer 7 features are required.
+
+  loadBalancerIP: null # If service.type is LoadBalancer, you can optionally set a specific external IP.
+                       # Useful for static IP requirements or pre-existing IP reservations.
+
 
 # Custom pod template to define your own specifications for the creation of the agent worker pods.
 # This should be YAML representing a valid corev1.PodTemplateSpec. This format is documented


### PR DESCRIPTION
https://hashicorp.atlassian.net/browse/IPL-7384

## Why

In https://github.com/hashicorp/terraform-enterprise-helm/pull/77, we set the appProtocol to https on the service. 

That change broke the deployment to Azure, which requires to define the health check path for https protocol, such as 

```
service:
  annotations:
    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/_health_check"
```

## What 
(1) Make the appProtocol configurable 
(2) Set the default to tcp (reverting the breaking change for Azure deployments)
(3) Add comments to the values.yaml to mention the Azure specific annotation
Without a good reason to set the appProtocol to https, I would prefer not introducing further annotations that are environment specific. 

## Testing 
Deployed to Azure.