### PR TITLE
Update release version for health check link changes

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 1.3.3
-appVersion: "v202410-1"
+version: 1.3.4
+appVersion: "v202411-1"


### PR DESCRIPTION
This is to bump the chart version in order to incorporate the latest changes for health check URLs into the helm chart:

https://github.com/hashicorp/terraform-enterprise-helm/pull/95