### PR TITLE
Fixing RBAC Role Binding for custom Service Account name

### DIFF
--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -55,6 +55,10 @@ roleRef:
   name: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
+  {{- if .Values.serviceAccount.name}}
+  name: {{ .Values.serviceAccount.name }}
+  {{- else }}
   name: {{ .Release.Namespace }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
Fixes #107

This fixes the RBAC RoleBinding to correctly handle the case where a custom Service Account name is used.