### PR TITLE
Add optional labels to the service created by the Helm Chart

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -12,6 +12,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.service.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}

--- a/values.yaml
+++ b/values.yaml
@@ -190,6 +190,9 @@ service:
     #   cloud.google.com/neg: '{"ingress": true}'
     # - For Azure, configure the health probe request path for HTTPS health checks:
     #   service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/_health_check"
+  labels: {}
+    # Add labels to the service created for Terraform Enterprise. Helpful if your metrics collection
+    # depends on ServiceMonitors instead of pod annotations.
 
   type: LoadBalancer # The type of service to create. Options: LoadBalancer, ClusterIP, NodePort.
                      # - LoadBalancer: Exposes the service externally using a cloud provider's load balancer.


### PR DESCRIPTION
Some organizations may not utilize pod annotations to collect metrics from k8s pods, opting instead to leverage the monitoring.coreos.com ServiceMonitor CRD. This utilizes labels to select the Service in kubernetes, which we are currently unable to set in the helm chart. This PR adds this missing functionality.