### PR TITLE
allow secrets and variables to use valueFrom

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -67,22 +67,48 @@ Create the name of the service account to use
 
 {{/*
 Prints the key-value pair from the 'env.variables' entry in the Values file.
+Excludes any non-string values, as `valueFrom` is handled separately.
 */}}
-{{- define "helpers.list-env-variables"}}
+{{- define "helpers.list-configmap-env-variables"}}
 {{- range $key, $val := .Values.env.variables }}
+{{- if kindOf $val | eq "string" }}
 {{ $key }}: {{ $val | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 
 {{/*
 Prints the key-value pair from the 'env.secrets' entry in the Values file
-and base64 encodes the value.
+and base64 encodes the value. Excludes any non-string values, as `valueFrom`
+is handled separately.
 */}}
 {{- define "helpers.list-env-secrets" }}
 {{- range $key, $val := .Values.env.secrets }}
+{{- if kindOf $val | eq "string" }}
 {{ $key }}: {{ trim $val | b64enc }}
 {{- end }}
 {{- end }}
+{{- end }}
+
+{{/*
+Prints the key-value pairs from the 'env.variables' and 'env.secrets'
+entries containing `valueFrom` in the Values file.
+*/}}
+{{- define "helpers.list-valueFrom-variables"}}
+{{- range $key, $val := .Values.env.variables }}
+{{- if and (kindOf $val | eq "map") (hasKey $val "valueFrom") }}
+- name: {{ $key }}
+  {{- toYaml $val | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- range $key, $val := .Values.env.secrets }}
+{{- if and (kindOf $val | eq "map") (hasKey $val "valueFrom") }}
+- name: {{ $key }}
+  {{- toYaml $val | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 
 {{/*
 Prints the file contents of the environment secrets file

--- a/templates/config-map.yaml
+++ b/templates/config-map.yaml
@@ -8,7 +8,7 @@ metadata:
   name: terraform-enterprise-env-config
   namespace: {{ .Release.Namespace }}
 data:
-  {{- include "helpers.list-env-variables" . | indent 2 }}
+  {{- include "helpers.list-configmap-env-variables" . | indent 2 }}
   TFE_RUN_PIPELINE_DRIVER: kubernetes
   TFE_RUN_PIPELINE_KUBERNETES_NAMESPACE: {{ include "helpers.agent-namespace" . }}
   {{- if or .Values.agentWorkerPodTemplate .Values.openshift.enabled }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
         {{- else }}
         {{- toYaml .Values.container.securityContext | nindent 10 }}
         {{- end }}
+        {{- with (include "helpers.list-valueFrom-variables" .) }}
+        env:
+          {{- . | indent 10 }}
+        {{- end }}
         envFrom:
           - configMapRef:
               name: terraform-enterprise-env-config


### PR DESCRIPTION
Relates to: https://github.com/hashicorp/terraform-enterprise-helm/issues/54
Also noticed as part of a support ticket.

This patch allows environment variables referenced under `$.Values.env.secrets` and `$.Values.env.variables` to accept `valueFrom` in order to reference external `Secret`s/`ConfigMap`s. This was implemented by editing the previous env helpers used by the `secret.yaml` and `config-map.yaml` templates to only template out string values. Then an additional helper was added to check for maps with the key `valueFrom` and templates them into `deployment.yaml` under the `PodSpec`'s env

Syntax in `values.yaml`:
```yaml
env:
  secrets: # or variables
    ENV_NAME_HERE:
      valueFrom:
        secretKeyRef: # or configMapKeyRef
          name: SECRET_NAME
          key: SECRET_KEY
```

Usecase: I have an operator that creates PostgreSQL databases (i.e. CrunchyData PGO, CNPG, etc) and creates a secret with the authentication info. I would like to reference this secret in `TFE_DATABASE_PASSWORD` and `TFE_DATABASE_USER`, but prior to this patch, cannot.