### PR TITLE
allow specifying extra volumes and mounts

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -59,6 +59,9 @@ spec:
           secret:
             secretName: terraform-enterprise-ca-certificates
         {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -123,6 +126,9 @@ spec:
           - name: ca-certificates
             mountPath: {{ include "cacert.path" . }}
             subPath: {{ .Values.tls.caCertFileName }}
+          {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
         ports:
         - containerPort: {{ .Values.tfe.privateHttpPort }}

--- a/values.yaml
+++ b/values.yaml
@@ -295,12 +295,26 @@ agents:
     annotations: {}
     labels: {}
 
-# Extra volumes to add to the deployment.
+# Extra volumes to add to the deployment's pod. 
+# Reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes
+# Usecases:
+## mount external secrets, such as certificates from cert-manager
+# extraVolumes:
+# - name: cert-manager-secret
+#   secret:
+#      secretName: tfe-example-com-tls
+#
+## associate a pre-existing PVC with /var/log/terraform-enterprise to have persistent logs
+# extraVolumes:
+# - name: logs
+#   persistentVolumeClaim:
+#      claimName: tfe-logs
 extraVolumes: []
   # - name: extra-volume
   #   emptyDir: {}
 
-# Extra volumes to add to the Terraform Enterprise container
+# Extra volume mounts to add to the Terraform Enterprise container. The name should match an "extraVolumes" entry
+# Reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1
 extraVolumeMounts: []
   # - name: extra-volume
   #   mountPath: /mnt/data

--- a/values.yaml
+++ b/values.yaml
@@ -294,3 +294,13 @@ agents:
     name: null
     annotations: {}
     labels: {}
+
+# Extra volumes to add to the deployment.
+extraVolumes: []
+  # - name: extra-volume
+  #   emptyDir: {}
+
+# Extra volumes to add to the Terraform Enterprise container
+extraVolumeMounts: []
+  # - name: extra-volume
+  #   mountPath: /mnt/data


### PR DESCRIPTION
Usecase: A customer has CA certificates required for TFE in an externally-managed secret. The current `tls` block doesn't give enough flexibility to mount a (or multiple) secrets as CA certificates. Additionally customers might want to do things such as making `/var/log/terraform-enterprise` persistent.