### PR TITLE
Add template for pod disruption budget

### DIFF
--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -3,6 +3,15 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: terraform-enterprise
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.pdb.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.pdb.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   minAvailable: {{ .Values.pdb.replicaCount }}
   selector:

--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -1,0 +1,11 @@
+{{ if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: terraform-enterprise
+spec:
+  minAvailable: {{ .Values.pdb.replicaCount }}
+  selector:
+    matchLabels:
+      app: terraform-enterprise
+{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -321,3 +321,11 @@ extraVolumes: []
 extraVolumeMounts: []
   # - name: extra-volume
   #   mountPath: /mnt/data
+
+# Pod Disruption Budget settings
+# Reference: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+pdb:
+  # Whether to create a PodDisruptionBudget for the Terraform Enterprise deployment.
+  enabled: false
+  # The number of replicas that must be available during disruptions.
+  replicaCount: 1

--- a/values.yaml
+++ b/values.yaml
@@ -329,3 +329,5 @@ pdb:
   enabled: false
   # The number of replicas that must be available during disruptions.
   replicaCount: 1
+  annotations: {}
+  labels: {}


### PR DESCRIPTION
[Jira](https://hashicorp.atlassian.net/browse/TF-23897)
This PR adds template for pod disruption budget.
How it was tested and validated is written on the jira ticket.

Fixes #51 