### PR TITLE
TF-23701: Bump Chart Version to 1.5.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 1.4.0
+version: 1.5.0
 appVersion: "v202502-1"


### PR DESCRIPTION
This pull request bumps the chart version to 1.5.0. I missed this before creating the 1.5.0 release, so I will redo that once this is merged.