### PR TITLE
TF-24985: Update chart to 1.6.1 with v202504-1

### DIFF
--- a/.github/workflows/sox-check.yml
+++ b/.github/workflows/sox-check.yml
@@ -1,7 +1,0 @@
-name: Sox Check
-on:
-  pull_request:
-    types: [opened, synchronize, edited]
-jobs:
-  sox-check:
-    uses: hashicorp/tf-enterprise-workflows/.github/workflows/sox-check.yml@main

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 1.7.0
+version: 1.6.1
 appVersion: "v202504-1"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 1.6.0
-appVersion: "v202503-1"
+version: 1.7.0
+appVersion: "v202504-1"


### PR DESCRIPTION
This pull request includes changes to update the version of the Terraform-Enterprise Chart and remove the Sox Check workflow.

Version updates:

* [`Chart.yaml`](diffhunk://diff-d954583aa4c24cff0039bc948abd7c694fc3dab2030231d11ed1b3cda9b4ddbeR9): Updated the `version` from `1.6.0` to `1.6.1` and the `appVersion` from `v202503-1` to `v202504-1`.

Workflow removal:

* [`.github/workflows/sox-check.yml`](diffhunk://#diff-204959bc72b79e317e20c215a88eb7a1e262b4191fd8e302fb76d829a86fed31L1-L7): Removed the Sox Check workflow configuration. This workflow has been [failing](https://github.com/hashicorp/terraform-enterprise-helm/actions/runs/14381412339) because it relied on a shared workflow housed in a private repository which was [not accessible](https://github.com/hashicorp/terraform-enterprise-helm/actions/runs/14381412339) from this public repository.