### PR TITLE
Add the ability of secondary hostname to the helm chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 1.6.1
+version: 1.6.2
 appVersion: "v202505-1"

--- a/templates/config-map.yaml
+++ b/templates/config-map.yaml
@@ -20,6 +20,8 @@ data:
   TFE_VAULT_DISABLE_MLOCK: "true"
   TFE_HTTP_PORT: "{{ .Values.tfe.privateHttpPort }}"
   TFE_HTTPS_PORT: "{{ .Values.tfe.privateHttpsPort }}"
+  TFE_TLS_CERT_FILE_SECONDARY: "{{ .Values.tlsSecondary.certMountPath }}"
+  TFE_TLS_KEY_FILE_SECONDARY:  "{{ .Values.tlsSecondary.keyMountPath }}"
   TFE_TLS_CERT_FILE: "{{ .Values.tls.certMountPath }}"
   TFE_TLS_KEY_FILE:  "{{ .Values.tls.keyMountPath }}"
   {{- if .Values.tls.caCertData }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
         {{- end }}
       labels:
         app: terraform-enterprise
+        app2: patrick-dmitry
         {{- if .Values.pod.labels }}
         {{- toYaml .Values.pod.labels | nindent 8 }}
         {{- end }}
@@ -54,6 +55,11 @@ spec:
         - name: certificates
           secret:
             secretName: {{ .Values.tls.certificateSecret }}
+        {{- if .Values.tlsSecondary.certificateSecret }}
+        - name: certificates-secondary
+          secret:
+            secretName: {{ .Values.tlsSecondary.certificateSecret }}  
+        {{- end }}
         {{- if .Values.tls.caCertData }}
         - name: ca-certificates
           secret:
@@ -128,6 +134,12 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:
+          - name: certificates-secondary
+            mountPath: {{ .Values.tlsSecondary.certMountPath }}
+            subPath: tls.crt
+          - name: certificates-secondary
+            mountPath: {{ .Values.tlsSecondary.keyMountPath }}
+            subPath: tls.key        
           - name: certificates
             mountPath: {{ .Values.tls.certMountPath }}
             subPath: tls.crt

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - name: certificates
           secret:
             secretName: {{ .Values.tls.certificateSecret }}
-        {{- if .Values.tlsSecondary.certificateSecret }}
+        {{- if .Values.tlsSecondary.certData }}
         - name: certificates-secondary
           secret:
             secretName: {{ .Values.tlsSecondary.certificateSecret }}  
@@ -134,12 +134,14 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:
+          {{- if .Values.tlsSecondary.certData }}
           - name: certificates-secondary
             mountPath: {{ .Values.tlsSecondary.certMountPath }}
             subPath: tls.crt
           - name: certificates-secondary
             mountPath: {{ .Values.tlsSecondary.keyMountPath }}
             subPath: tls.key        
+          {{- end }}  
           - name: certificates
             mountPath: {{ .Values.tls.certMountPath }}
             subPath: tls.crt

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -15,6 +15,20 @@ data:
   tls.key: {{ .Values.tls.keyData }}
 {{- end }}
 
+{{- if and .Values.tlsSecondary.certData .Values.tlsSecondary.keyData }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.tlsSecondary.certificateSecret }}
+  namespace: {{ .Release.Namespace }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.tlsSecondary.certData }}
+  tls.key: {{ .Values.tlsSecondary.keyData }}
+{{- end }}
+
+
 {{- if .Values.tls.caCertData }}
 ---
 apiVersion: v1

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -31,3 +31,32 @@ spec:
       appProtocol: {{ .Values.service.appProtocol }}
   selector:
     app: terraform-enterprise
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: terraform-enterprise-secondary
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceSecondary.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.serviceSecondary.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.serviceSecondary.type }}
+  {{- if and (eq .Values.serviceSecondary.type "LoadBalancer") .Values.serviceSecondary.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.serviceSecondary.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: https-port
+      port: {{ .Values.serviceSecondary.port }}
+      {{- if eq .Values.serviceSecondary.type "NodePort" }}
+      nodePort: {{ .Values.serviceSecondary.nodePort }}
+      {{- end }}
+      targetPort: {{ .Values.tfe.privateHttpsPort }}
+      appProtocol: {{ .Values.serviceSecondary.appProtocol }}
+  selector:
+    app: terraform-enterprise    

--- a/values.yaml
+++ b/values.yaml
@@ -65,6 +65,15 @@ tls:
   # keyData:
   # caCertData:
 
+
+tlsSecondary:
+  certificateSecret: terraform-enterprise-certificates-secondary
+  certMountPath: /etc/ssl/private/terraform-enterprise-secondary/cert.pem
+  keyMountPath: /etc/ssl/private/terraform-enterprise-secondary/key.pem
+  # certData:
+  # keyData:
+  # caCertData:  
+
 tfe:
   metrics:
     enable: false

--- a/values.yaml
+++ b/values.yaml
@@ -72,7 +72,6 @@ tlsSecondary:
   keyMountPath: /etc/ssl/private/terraform-enterprise-secondary/key.pem
   # certData:
   # keyData:
-  # caCertData:  
 
 tfe:
   metrics:
@@ -204,6 +203,35 @@ service:
     # depends on ServiceMonitors instead of pod annotations.
 
   type: LoadBalancer # The type of service to create. Options: LoadBalancer, ClusterIP, NodePort.
+                     # - LoadBalancer: Exposes the service externally using a cloud provider's load balancer.
+                     # - ClusterIP: Default type; exposes the service only within the cluster.
+                     # - NodePort: Exposes the service on a static port on each cluster node.
+
+  port: 443          # The port exposed by the service (external port).
+
+  nodePort: 32443    # If service.type is NodePort, this sets the external port on cluster nodes.
+                     # Ignored for LoadBalancer and ClusterIP types.
+
+  appProtocol: tcp   # Application protocol for the service.
+                     # - Default is "tcp" for broad compatibility across cloud providers.
+                     # - Set to "https" if Gateway API or Layer 7 features are required.
+
+  loadBalancerIP: null # If service.type is LoadBalancer, you can optionally set a specific external IP.
+                       # Useful for static IP requirements or pre-existing IP reservations.
+
+serviceSecondary:
+  annotations: {}
+    # Add annotations here for specific cloud provider configurations.
+    # Examples:
+    # - For Google Cloud, use the NEG (Network Endpoint Group) annotation:
+    #   cloud.google.com/neg: '{"ingress": true}'
+    # - For Azure, configure the health probe request path for HTTPS health checks:
+    #   service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/_health_check"
+  labels: {}
+    # Add labels to the service created for Terraform Enterprise. Helpful if your metrics collection
+    # depends on ServiceMonitors instead of pod annotations.
+
+  type: ClusterIP    # The type of service to create. Options: LoadBalancer, ClusterIP, NodePort.
                      # - LoadBalancer: Exposes the service externally using a cloud provider's load balancer.
                      # - ClusterIP: Default type; exposes the service only within the cluster.
                      # - NodePort: Exposes the service on a static port on each cluster node.


### PR DESCRIPTION
Based on the requirement with internal reference TF-24247

I made sure of the following changes

The helm chart was not able to use the ability of the secondary hostname features because it was missing the option to add the secondary certificates as needed 

```
    TFE_TLS_CERT_FILE_SECONDARY: /etc/ssl/private/terraform-enterprise-secondary/cert.pem
    TFE_TLS_KEY_FILE_SECONDARY: /etc/ssl/private/terraform-enterprise-secondary/key.pem    
```

To accomplish that I added the following option to the values

```
tlsSecondary:
  certificateSecret: terraform-enterprise-certificates-secondary
  certMountPath: /etc/ssl/private/terraform-enterprise-secondary/cert.pem
  keyMountPath: /etc/ssl/private/terraform-enterprise-secondary/key.pem
  # certData:
  # keyData:
```

If the `tlsSecondary.certData` is not specified then it will not create the secret or any reference in the pod itself

With the above values

- It will create secondary secret for the certificates
- will mount this in the the pod at the specified location

Also added the serviceSecondary to make sure you can specify alternative configured for the second hostname. The default will be a `clusterIP` if no value is defined. 

```
serviceSecondary:
  annotations: null
  type: LoadBalancer  
```


I tested this and looks good to me. Appreciate a second look on the changes
