### PR TITLE
Add secondary hostname capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/example/terraform-enterprise-prereqs/charts
 .DS_Store
+overrides.yaml

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 1.6.1
+version: 1.6.2
 appVersion: "v202505-1"

--- a/templates/config-map.yaml
+++ b/templates/config-map.yaml
@@ -20,6 +20,8 @@ data:
   TFE_VAULT_DISABLE_MLOCK: "true"
   TFE_HTTP_PORT: "{{ .Values.tfe.privateHttpPort }}"
   TFE_HTTPS_PORT: "{{ .Values.tfe.privateHttpsPort }}"
+  TFE_TLS_CERT_FILE_SECONDARY: "{{ .Values.tlsSecondary.certMountPath }}"
+  TFE_TLS_KEY_FILE_SECONDARY:  "{{ .Values.tlsSecondary.keyMountPath }}"
   TFE_TLS_CERT_FILE: "{{ .Values.tls.certMountPath }}"
   TFE_TLS_KEY_FILE:  "{{ .Values.tls.keyMountPath }}"
   {{- if .Values.tls.caCertData }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -54,6 +54,11 @@ spec:
         - name: certificates
           secret:
             secretName: {{ .Values.tls.certificateSecret }}
+        {{- if and .Values.tlsSecondary.certData .Values.tlsSecondary.keyData }}
+        - name: certificates-secondary
+          secret:
+            secretName: {{ .Values.tlsSecondary.certificateSecret }}  
+        {{- end }}
         {{- if .Values.tls.caCertData }}
         - name: ca-certificates
           secret:
@@ -128,6 +133,14 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:
+          {{- if and .Values.tlsSecondary.certData .Values.tlsSecondary.keyData }}
+          - name: certificates-secondary
+            mountPath: {{ .Values.tlsSecondary.certMountPath }}
+            subPath: tls.crt
+          - name: certificates-secondary
+            mountPath: {{ .Values.tlsSecondary.keyMountPath }}
+            subPath: tls.key        
+          {{- end }}  
           - name: certificates
             mountPath: {{ .Values.tls.certMountPath }}
             subPath: tls.crt

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -15,6 +15,20 @@ data:
   tls.key: {{ .Values.tls.keyData }}
 {{- end }}
 
+{{- if and .Values.tlsSecondary.certData .Values.tlsSecondary.keyData }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.tlsSecondary.certificateSecret }}
+  namespace: {{ .Release.Namespace }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.tlsSecondary.certData }}
+  tls.key: {{ .Values.tlsSecondary.keyData }}
+{{- end }}
+
+
 {{- if .Values.tls.caCertData }}
 ---
 apiVersion: v1

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -31,3 +31,34 @@ spec:
       appProtocol: {{ .Values.service.appProtocol }}
   selector:
     app: terraform-enterprise
+---
+{{- if .Values.env.variables.TFE_HOSTNAME_SECONDARY }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: terraform-enterprise-secondary
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceSecondary.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.serviceSecondary.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.serviceSecondary.type }}
+  {{- if and (eq .Values.serviceSecondary.type "LoadBalancer") .Values.serviceSecondary.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.serviceSecondary.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: https-port
+      port: {{ .Values.serviceSecondary.port }}
+      {{- if eq .Values.serviceSecondary.type "NodePort" }}
+      nodePort: {{ .Values.serviceSecondary.nodePort }}
+      {{- end }}
+      targetPort: {{ .Values.tfe.privateHttpsPort }}
+      appProtocol: {{ .Values.serviceSecondary.appProtocol }}
+  selector:
+    app: terraform-enterprise    
+{{- end}}

--- a/values.yaml
+++ b/values.yaml
@@ -65,6 +65,14 @@ tls:
   # keyData:
   # caCertData:
 
+
+tlsSecondary:
+  certificateSecret: terraform-enterprise-certificates-secondary
+  certMountPath: /etc/ssl/private/terraform-enterprise-secondary/cert.pem
+  keyMountPath: /etc/ssl/private/terraform-enterprise-secondary/key.pem
+  # certData:
+  # keyData:
+
 tfe:
   metrics:
     enable: false
@@ -195,6 +203,35 @@ service:
     # depends on ServiceMonitors instead of pod annotations.
 
   type: LoadBalancer # The type of service to create. Options: LoadBalancer, ClusterIP, NodePort.
+                     # - LoadBalancer: Exposes the service externally using a cloud provider's load balancer.
+                     # - ClusterIP: Default type; exposes the service only within the cluster.
+                     # - NodePort: Exposes the service on a static port on each cluster node.
+
+  port: 443          # The port exposed by the service (external port).
+
+  nodePort: 32443    # If service.type is NodePort, this sets the external port on cluster nodes.
+                     # Ignored for LoadBalancer and ClusterIP types.
+
+  appProtocol: tcp   # Application protocol for the service.
+                     # - Default is "tcp" for broad compatibility across cloud providers.
+                     # - Set to "https" if Gateway API or Layer 7 features are required.
+
+  loadBalancerIP: null # If service.type is LoadBalancer, you can optionally set a specific external IP.
+                       # Useful for static IP requirements or pre-existing IP reservations.
+
+serviceSecondary:
+  annotations: {}
+    # Add annotations here for specific cloud provider configurations.
+    # Examples:
+    # - For Google Cloud, use the NEG (Network Endpoint Group) annotation:
+    #   cloud.google.com/neg: '{"ingress": true}'
+    # - For Azure, configure the health probe request path for HTTPS health checks:
+    #   service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/_health_check"
+  labels: {}
+    # Add labels to the service created for Terraform Enterprise. Helpful if your metrics collection
+    # depends on ServiceMonitors instead of pod annotations.
+
+  type: ClusterIP    # The type of service to create. Options: LoadBalancer, ClusterIP, NodePort.
                      # - LoadBalancer: Exposes the service externally using a cloud provider's load balancer.
                      # - ClusterIP: Default type; exposes the service only within the cluster.
                      # - NodePort: Exposes the service on a static port on each cluster node.


### PR DESCRIPTION
Based on the requirement with internal reference TF-24247

I made sure of the following changes

The helm chart was not able to use the ability of the secondary hostname features because it was missing the option to add the secondary certificates as needed 

To accomplish that I added the following option to the values

```
tlsSecondary:
  certificateSecret: terraform-enterprise-certificates-secondary
  certMountPath: /etc/ssl/private/terraform-enterprise-secondary/cert.pem
  keyMountPath: /etc/ssl/private/terraform-enterprise-secondary/key.pem
  # certData:
  # keyData:
```

If the `tlsSecondary.certData`  and `tlsSecondary.keyData` is not specified then it will not create the secret or any reference in the pod itself

Also added the serviceSecondary to make sure you can specify alternative service configured for the second hostname. If the `.Values.env.variables.TFE_HOSTNAME_SECONDARY` is not specified it will not be created

```
serviceSecondary:
  annotations: null
  type: LoadBalancer  
```

### I tested in the following way. 

**no secondary hostname references**
This should still work with the adjustments done to the PR. The environment gets created without issues. 

**Secondary hostname references**
It should add the secondary hostname resources. The environment gets created without issues. 

I add the following values

```
env:
  variables:
    TFE_HOSTNAME_SECONDARY: "<data>"
    TFE_OIDC_HOSTNAME_CHOICE: secondary
    TFE_VCS_HOSTNAME_CHOICE: secondary
    TFE_SAML_HOSTNAME_CHOICE: secondary
    TFE_RUN_TASK_HOSTNAME_CHOICE: secondary

serviceSecondary:
  annotations: null
  type: LoadBalancer  
  
tlsSecondary:
  certData: <data>
  keyData: <data>
```

I use the `helm upgrade` command

As a result
- The service gets created
- The secrets with certificates gets created
- the deployment with references gets created for the secondary certificates and volumes

You now have 2 loadbalancers and you can connect to the secondary hostname with VCS 