### PR TITLE
Fix chart version for v1.6.2

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 1.6.1
+version: 1.6.2
 appVersion: "v202505-1"


### PR DESCRIPTION
v1.6.2 was released without updating the chart version, so Helm is unable to recognize it. See line 9:

https://github.com/hashicorp/terraform-enterprise-helm/compare/v1.6.1...v1.6.2