### PR TITLE
TF-25428: Update chart for v202506-1

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -7,4 +7,4 @@ kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
 version: 1.6.3
-appVersion: "v202505-1"
+appVersion: "v202506-1"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 1.6.2
+version: 1.6.3
 appVersion: "v202505-1"


### PR DESCRIPTION
This pull request includes a version update for the `terraform-enterprise` Helm chart in the `Chart.yaml` file.

Version updates:

* Updated the `version` field from `1.6.2` to `1.6.3`.
* Updated the `appVersion` field from `v202505-1` to `v202506-1`.