### PR TITLE
Update the default resource values

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -44,8 +44,8 @@ container:
 # If you do want to specify resource limits, uncomment the following lines and adjust them as necessary.
 resources:
   requests:
-    memory: "2500Mi"
-    cpu: "750m"
+    memory: "8192Mi"
+    cpu: "4000m"
   # limits:
   #   memory: ""
   #   cpu: ""


### PR DESCRIPTION
The support team gets tickets where customers follow the documentation to deploy Terraform Enterprise on Kubernetes/OpenShift and have performance issues with Terraform Enterprise itself

The default resource values are low and we think by making the default values higher we will have less tickets regarding performance issues out of the box. 

The new values are based on the official documentation as found [here](https://developer.hashicorp.com/terraform/enterprise/deploy/replicated/requirements/hardware)
