### PR TITLE
Add admin HTTPS port

### DIFF
--- a/templates/config-map.yaml
+++ b/templates/config-map.yaml
@@ -20,6 +20,7 @@ data:
   TFE_VAULT_DISABLE_MLOCK: "true"
   TFE_HTTP_PORT: "{{ .Values.tfe.privateHttpPort }}"
   TFE_HTTPS_PORT: "{{ .Values.tfe.privateHttpsPort }}"
+  TFE_ADMIN_HTTPS_PORT: "{{ .Values.tfe.adminHttpsPort }}"
   {{- if or (and .Values.tlsSecondary.certData .Values.tlsSecondary.keyData) .Values.tlsSecondary.certificateSecret }}
   TFE_TLS_CERT_FILE_SECONDARY: "{{ .Values.tlsSecondary.certMountPath }}"
   TFE_TLS_KEY_FILE_SECONDARY:  "{{ .Values.tlsSecondary.keyMountPath }}"

--- a/values.yaml
+++ b/values.yaml
@@ -80,6 +80,7 @@ tfe:
     httpsPort: 9091
   privateHttpPort: 8080
   privateHttpsPort: 8443
+  adminHttpsPort: 8446
   ## Readiness probe settings customize the terraform-enterprise health check path, eg: to use the full service dependency check
   # readinessProbePath: "/_health_check?full"
   # readinessProbeScheme: "HTTP"


### PR DESCRIPTION
[Jira](https://hashicorp.atlassian.net/browse/IPL-8302)

This PR adds `TFE_ADMIN_HTTPS_PORT` variable for Admin API.

Rendering the template via helm template debug gives:
```
# Source: terraform-enterprise/templates/config-map.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: terraform-enterprise-env-config
  namespace: default
data:  
  TFE_RUN_PIPELINE_DRIVER: kubernetes
  TFE_RUN_PIPELINE_KUBERNETES_NAMESPACE: default-agents
  TFE_VAULT_DISABLE_MLOCK: "true"
  TFE_HTTP_PORT: "8080"
  TFE_HTTPS_PORT: "8443"
  TFE_ADMIN_HTTPS_PORT: "8446"
  TFE_TLS_CERT_FILE: "/etc/ssl/private/terraform-enterprise/cert.pem"
  TFE_TLS_KEY_FILE:  "/etc/ssl/private/terraform-enterprise/key.pem"
---
```