### PR TITLE
Simplify support for non-vault csi

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,12 +85,81 @@ The custom pod template must be a valid `corev1.PodTemplateSpec` and should be p
 documented at <https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec>.
 
 
-## Vault CSI Provider
-Terraform Enterprise now supports [Vault CSI provider](https://developer.hashicorp.com/vault/docs/platform/k8s/csi). This allows TFE pods to consume Vault secrets using CSI Secrets Store volumes.
+## CSI Secret Providers
+Terraform Enterprise supports mounting secrets through a Kubernetes [Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/) `SecretProviderClass`. The chart keeps [Vault CSI provider](https://developer.hashicorp.com/vault/docs/platform/k8s/csi) as the default configuration path, and also allows passing provider-specific configuration for other CSI providers.
 
 The settings for this can be found in the `values.yaml` file under the `csi` section.
-If `csi.enabled` is set to true, the Vault CSI provider will be used to retrieve secrets, as it is the only supported provider. This requires using an external Vault.
+If `csi.enabled` is set to true:
+
+- `csi.provider: vault` with an empty `csi.parameters` preserves the existing Vault-specific configuration using `csi.vaultRole`, `csi.vaultAddress`, and `csi.secrets`.
+- Any other provider can be used by setting `csi.provider` and supplying the provider-specific `SecretProviderClass.spec.parameters` through `csi.parameters`.
 
 The Secrets Store CSI Driver also supports syncing to Kubernetes secret objects. The `secretObjects` section adds secret syncing for TFE if values are provided.
 
-**Note:** The Vault CSI Provider requires the [CSI Secret Store Driver](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html) to be installed.
+Example:
+
+```yaml
+csi:
+  enabled: true
+  provider: aws
+  mountPath: /mnt/secrets-store
+  parameters:
+    region: us-east-1
+    usePodIdentity: "false"
+    objects: |
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-license"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-license"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-database-password"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-database-password"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-redis-password"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-redis-password"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-tls-cert"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-tls-cert"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-tls-privkey"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-tls-privkey"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-tls-ca-bundle"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-tls-ca-bundle"
+  secretObjects:
+    - secretName: tfe-license
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-license
+    - secretName: tfe-database-password
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-database-password
+    - secretName: tfe-redis-password
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-redis-password
+    - secretName: tfe-tls-cert
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-tls-cert
+    - secretName: tfe-tls-privkey
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-tls-privkey
+    - secretName: tfe-tls-ca-bundle
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-tls-ca-bundle
+```
+
+AWS example:
+
+See [docs/example/aws-csi-override.yaml](./example/aws-csi-override.yaml) for an example using the AWS provider with Secrets Manager and syncing selected keys into a Kubernetes secret.
+
+**Note:** The required `csi.parameters` keys and object format depend on the selected provider. The appropriate CSI provider and the [CSI Secret Store Driver](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html) must already be installed in the cluster.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,30 +107,29 @@ csi:
     region: us-east-1
     usePodIdentity: "false"
     objects: |
-      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-license"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:sandbox-tfe-license-544c-z0Rv08"
         objectType: "secretsmanager"
         objectAlias: "tfe-license"
-      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-database-password"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:sandbox-tfe-encryption-password-544c-ef1ltK"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-encryption"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:sandbox-tfe-database-password-544c-GWvUj5"
         objectType: "secretsmanager"
         objectAlias: "tfe-database-password"
-      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-redis-password"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:sandbox-tfe-redis-password-544c-SWr8Q6"
         objectType: "secretsmanager"
         objectAlias: "tfe-redis-password"
-      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-tls-cert"
-        objectType: "secretsmanager"
-        objectAlias: "tfe-tls-cert"
-      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-tls-privkey"
-        objectType: "secretsmanager"
-        objectAlias: "tfe-tls-privkey"
-      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-tls-ca-bundle"
-        objectType: "secretsmanager"
-        objectAlias: "tfe-tls-ca-bundle"
   secretObjects:
     - secretName: tfe-license
       type: Opaque
       data:
         - key: value
           objectName: tfe-license
+    - secretName: tfe-encryption
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-encryption
     - secretName: tfe-database-password
       type: Opaque
       data:
@@ -141,21 +140,6 @@ csi:
       data:
         - key: value
           objectName: tfe-redis-password
-    - secretName: tfe-tls-cert
-      type: Opaque
-      data:
-        - key: value
-          objectName: tfe-tls-cert
-    - secretName: tfe-tls-privkey
-      type: Opaque
-      data:
-        - key: value
-          objectName: tfe-tls-privkey
-    - secretName: tfe-tls-ca-bundle
-      type: Opaque
-      data:
-        - key: value
-          objectName: tfe-tls-ca-bundle
 ```
 
 AWS example:

--- a/docs/example/aws-csi-override.yaml
+++ b/docs/example/aws-csi-override.yaml
@@ -1,6 +1,7 @@
 csi:
   enabled: true
   provider: aws
+  secretProviderClass: terraform-enterprise-aws-secrets
   mountPath: /mnt/secrets-store
   parameters:
     region: us-east-1

--- a/docs/example/aws-csi-override.yaml
+++ b/docs/example/aws-csi-override.yaml
@@ -6,16 +6,16 @@ csi:
     region: us-east-1
     usePodIdentity: "false"
     objects: |
-      - objectName: "arn:aws:secretsmanager:us-east-1:050752626041:secret:sandbox-tfe-license-544c-z0Rv08"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:sandbox-tfe-license-544c-z0Rv08"
         objectType: "secretsmanager"
         objectAlias: "tfe-license"
-      - objectName: "arn:aws:secretsmanager:us-east-1:050752626041:secret:sandbox-tfe-encryption-password-544c-ef1ltK"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:sandbox-tfe-encryption-password-544c-ef1ltK"
         objectType: "secretsmanager"
         objectAlias: "tfe-encryption"
-      - objectName: "arn:aws:secretsmanager:us-east-1:050752626041:secret:sandbox-tfe-database-password-544c-GWvUj5"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:sandbox-tfe-database-password-544c-GWvUj5"
         objectType: "secretsmanager"
         objectAlias: "tfe-database-password"
-      - objectName: "arn:aws:secretsmanager:us-east-1:050752626041:secret:sandbox-tfe-redis-password-544c-SWr8Q6"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:sandbox-tfe-redis-password-544c-SWr8Q6"
         objectType: "secretsmanager"
         objectAlias: "tfe-redis-password"
   secretObjects:

--- a/docs/example/aws-csi-override.yaml
+++ b/docs/example/aws-csi-override.yaml
@@ -1,11 +1,3 @@
-# Example override values for using the AWS Secrets Store CSI provider with
-# Terraform Enterprise on EKS.
-#
-# Prerequisites:
-# - The Secrets Store CSI Driver is installed in the cluster.
-# - The AWS provider for the Secrets Store CSI Driver is installed.
-# - The Terraform Enterprise service account is authorized through IRSA or EKS Pod Identity.
-
 csi:
   enabled: true
   provider: aws
@@ -14,27 +6,18 @@ csi:
     region: us-east-1
     usePodIdentity: "false"
     objects: |
-      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-license"
+      - objectName: "arn:aws:secretsmanager:us-east-1:050752626041:secret:sandbox-tfe-license-544c-z0Rv08"
         objectType: "secretsmanager"
         objectAlias: "tfe-license"
-      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-encryption"
+      - objectName: "arn:aws:secretsmanager:us-east-1:050752626041:secret:sandbox-tfe-encryption-password-544c-ef1ltK"
         objectType: "secretsmanager"
-        objectAlias: "tfe-license"
-      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-database-password"
+        objectAlias: "tfe-encryption"
+      - objectName: "arn:aws:secretsmanager:us-east-1:050752626041:secret:sandbox-tfe-database-password-544c-GWvUj5"
         objectType: "secretsmanager"
         objectAlias: "tfe-database-password"
-      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-redis-password"
+      - objectName: "arn:aws:secretsmanager:us-east-1:050752626041:secret:sandbox-tfe-redis-password-544c-SWr8Q6"
         objectType: "secretsmanager"
         objectAlias: "tfe-redis-password"
-      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-tls-cert"
-        objectType: "secretsmanager"
-        objectAlias: "tfe-tls-cert"
-      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-tls-privkey"
-        objectType: "secretsmanager"
-        objectAlias: "tfe-tls-privkey"
-      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-tls-ca-bundle"
-        objectType: "secretsmanager"
-        objectAlias: "tfe-tls-ca-bundle"
   secretObjects:
     - secretName: tfe-license
       type: Opaque
@@ -56,25 +39,15 @@ csi:
       data:
         - key: value
           objectName: tfe-redis-password
-    - secretName: tfe-tls-cert
-      type: Opaque
-      data:
-        - key: value
-          objectName: tfe-tls-cert
-    - secretName: tfe-tls-privkey
-      type: Opaque
-      data:
-        - key: value
-          objectName: tfe-tls-privkey
-    - secretName: tfe-tls-ca-bundle
-      type: Opaque
-      data:
-        - key: value
-          objectName: tfe-tls-ca-bundle
+
 
 env:
+  # Abbreviating to just show secretKeyRefs
   # Map each synced Kubernetes Secret key into the TFE container environment.
   secretKeyRefs:
+    - name: TFE_ENCRYPTION_PASSWORD
+      secretName: tfe-encryption
+      key: value
     - name: TFE_LICENSE
       secretName: tfe-license
       key: value

--- a/docs/example/aws-csi-override.yaml
+++ b/docs/example/aws-csi-override.yaml
@@ -1,0 +1,78 @@
+# Example override values for using the AWS Secrets Store CSI provider with
+# Terraform Enterprise on EKS.
+#
+# Prerequisites:
+# - The Secrets Store CSI Driver is installed in the cluster.
+# - The AWS provider for the Secrets Store CSI Driver is installed.
+# - The Terraform Enterprise service account is authorized through IRSA or EKS Pod Identity.
+
+csi:
+  enabled: true
+  provider: aws
+  mountPath: /mnt/secrets-store
+  parameters:
+    region: us-east-1
+    usePodIdentity: "false"
+    objects: |
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-license"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-license"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-database-password"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-database-password"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-redis-password"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-redis-password"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-tls-cert"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-tls-cert"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-tls-privkey"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-tls-privkey"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-tls-ca-bundle"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-tls-ca-bundle"
+  secretObjects:
+    - secretName: tfe-license
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-license
+    - secretName: tfe-database-password
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-database-password
+    - secretName: tfe-redis-password
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-redis-password
+    - secretName: tfe-tls-cert
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-tls-cert
+    - secretName: tfe-tls-privkey
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-tls-privkey
+    - secretName: tfe-tls-ca-bundle
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-tls-ca-bundle
+
+env:
+  # Map each synced Kubernetes Secret key into the TFE container environment.
+  secretKeyRefs:
+    - name: TFE_LICENSE
+      secretName: tfe-license
+      key: value
+    - name: TFE_DATABASE_PASSWORD
+      secretName: tfe-database-password
+      key: value
+    - name: TFE_REDIS_PASSWORD
+      secretName: tfe-redis-password
+      key: value

--- a/docs/example/aws-csi-override.yaml
+++ b/docs/example/aws-csi-override.yaml
@@ -17,6 +17,9 @@ csi:
       - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-license"
         objectType: "secretsmanager"
         objectAlias: "tfe-license"
+      - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-encryption"
+        objectType: "secretsmanager"
+        objectAlias: "tfe-license"
       - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-database-password"
         objectType: "secretsmanager"
         objectAlias: "tfe-database-password"
@@ -38,6 +41,11 @@ csi:
       data:
         - key: value
           objectName: tfe-license
+    - secretName: tfe-encryption
+      type: Opaque
+      data:
+        - key: value
+          objectName: tfe-encryption
     - secretName: tfe-database-password
       type: Opaque
       data:

--- a/templates/secretproviderclass.yaml
+++ b/templates/secretproviderclass.yaml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 {{- if and (not .Values.preupgradeCheck.enabled) .Values.csi.enabled }}
+{{- $provider := .Values.csi.provider | default "vault" }}
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
@@ -16,7 +17,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  provider: vault
+  provider: {{ $provider }}
+  {{- if .Values.csi.parameters }}
+  parameters:
+    {{- toYaml .Values.csi.parameters | nindent 4 }}
+  {{- else if eq $provider "vault" }}
   parameters:
     roleName: "{{ .Values.csi.vaultRole }}"
     vaultAddress: "{{ .Values.csi.vaultAddress }}"
@@ -26,16 +31,9 @@ spec:
         secretPath: "{{ .secretPath }}"
         secretKey: "{{ .secretKey }}"
     {{- end }}
+  {{- end }}
   {{- if .Values.csi.secretObjects }}
   secretObjects:
-  {{- range .Values.csi.secretObjects }}
-  - data:
-    {{- range .data }}
-    - key: {{ .key }}
-      objectName: {{ .objectName }}
-    {{- end }}
-    secretName: {{ .secretName }}
-    type: {{ .type }}
-  {{- end }}
+    {{- toYaml .Values.csi.secretObjects | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -421,15 +421,21 @@ csi:
   # Provider-specific SecretProviderClass parameters.
   # When set, these are rendered directly and override the legacy Vault-specific fields below.
   # Example for a non-Vault provider:
+  # provider: aws
+  # mountPath: /mnt/secrets-store
   # parameters:
+  #   region: us-east-1
   #   usePodIdentity: "false"
-  #   keyvaultName: my-keyvault
-  #   tenantId: 00000000-0000-0000-0000-000000000000
   #   objects: |
-  #     array:
-  #       - |
-  #         objectName: example-secret
-  #         objectType: secret
+  #     - objectName: "arn:aws:secretsmanager:us-east-1:123456789012:secret:tfe-license-544c-z0Rv08"
+  #       objectType: "secretsmanager"
+  #       objectAlias: "tfe-license"
+  # secretObjects:
+  #   - secretName: tfe-license
+  #     type: Opaque
+  #     data:
+  #       - key: value
+  #         objectName: tfe-license
   parameters: {}
   # Legacy Vault-only fields retained for backward compatibility when csi.provider is vault
   # and csi.parameters is empty.

--- a/values.yaml
+++ b/values.yaml
@@ -416,6 +416,7 @@ csi:
   enabled: false
   annotations: {}
   labels: {}
+  # If not using Vault, provide a name to better identify the provider. 
   secretProviderClass: terraform-enterprise-vault-secrets
   provider: vault
   # Provider-specific SecretProviderClass parameters.

--- a/values.yaml
+++ b/values.yaml
@@ -349,13 +349,13 @@ env:
     # TFE_IACT_SUBNETS: ""
     # TFE_IACT_TIME_LIMIT: ""
   # secretKeyRefs can be used to inject external Kubernetes secrets into the environment.
-  secretKeyRefs: {}
+  secretKeyRefs: []
     # Name is the name of the environment variable.
     # - name: SECRET_ENV_VAR
     #   secretName: my-secret
     #   key: secret-key
   # configMapKeyRefs can be used to inject external Kubernetes configmap entries into the environment.
-  configMapKeyRefs: {}
+  configMapKeyRefs: []
     # Name is the name of the environment variable.
     # - name: CONFIG_ENV_VAR
     #   configMapName: my-configmap
@@ -409,12 +409,30 @@ pdb:
   annotations: {}
   labels: {}
 
-# CSI driver settings for Vault provider
+# CSI driver settings for Secrets Store CSI providers.
+# By default the chart preserves the existing Vault-specific behavior.
+# To use another provider, set csi.provider and csi.parameters.
 csi:
   enabled: false
   annotations: {}
   labels: {}
   secretProviderClass: terraform-enterprise-vault-secrets
+  provider: vault
+  # Provider-specific SecretProviderClass parameters.
+  # When set, these are rendered directly and override the legacy Vault-specific fields below.
+  # Example for a non-Vault provider:
+  # parameters:
+  #   usePodIdentity: "false"
+  #   keyvaultName: my-keyvault
+  #   tenantId: 00000000-0000-0000-0000-000000000000
+  #   objects: |
+  #     array:
+  #       - |
+  #         objectName: example-secret
+  #         objectType: secret
+  parameters: {}
+  # Legacy Vault-only fields retained for backward compatibility when csi.provider is vault
+  # and csi.parameters is empty.
   vaultRole: ""
   vaultAddress: "" # Example: http://vault.vault-namespace.svc.cluster.local:8200
   mountPath: "" # Example: /mnt/secrets-store


### PR DESCRIPTION
This pull request expands support for Kubernetes Secrets Store CSI providers in the helm chart. Previously, Vault was the only hardcoded provider when enabling csi. 

- Updated template to allow users to add other providers (keeping vault the default, if other provider is not specified) 
- Added example usage for AWS Secrets manager - I did not provide instructions on setting up. Assuming users have the knowledge/experience setting up those prereqs on their cluster. 
- Updated configuration documentation to include non-vault setup. 

Tested and deployed within AWS (if there is interest with Azure/GCP I could come up with quick examples as well. AWS was all I had handy.): 

**CSI mount**
```yaml
➜  terraform-enterprise-helm git:(f-nonvault-csi-providers) kubectl get secretproviderclasspodstatus -n tfe -o yaml
apiVersion: v1
items:
- apiVersion: secrets-store.csi.x-k8s.io/v1
  kind: SecretProviderClassPodStatus
  metadata:
    creationTimestamp: "2026-04-14T13:38:45Z"
    generation: 1
    labels:
      internal.secrets-store.csi.k8s.io/node-name: ip-10-0-9-248.ec2.internal
    name: terraform-enterprise-57c6d58559-7xzhb-tfe-terraform-enterprise-vault-secrets
    namespace: tfe
    ownerReferences:
    - apiVersion: v1
      kind: Pod
      name: terraform-enterprise-57c6d58559-7xzhb
      uid: 346a7e66-e0f0-43ab-8144-c2f25f112418
    resourceVersion: "259239"
    uid: 005ffd34-62b6-4ae8-bf31-99672a758382
  status:
    mounted: true
    objects:
    - id: tfe-database-password
      version: terraform-20260225005547905400000009
    - id: tfe-encryption
      version: terraform-2026022500554799660000000b
    - id: tfe-license
      version: terraform-2026022500554793100000000a
    - id: tfe-redis-password
      version: terraform-20260225005547899000000008
    podName: terraform-enterprise-57c6d58559-7xzhb
    secretProviderClassName: terraform-enterprise-vault-secrets
    targetPath: /var/lib/kubelet/pods/346a7e66-e0f0-43ab-8144-c2f25f112418/volumes/kubernetes.io~csi/secrets-store/mount
kind: List
metadata:
  resourceVersion: ""
```

**Secrets**
```yaml
➜  terraform-enterprise-helm git:(f-nonvault-csi-providers) kubectl get secret -n tfe tfe-license tfe-encryption tfe-database-password tfe-redis-password
NAME                    TYPE     DATA   AGE
tfe-license             Opaque   1      5h10m
tfe-encryption          Opaque   1      5h10m
tfe-database-password   Opaque   1      5h10m
tfe-redis-password      Opaque   1      5h10m
```

**Environment Configured**
```yaml
    Environment:
      TFE_ENCRYPTION_PASSWORD:      <set to the key 'value' in secret 'tfe-encryption'>         Optional: false
      TFE_LICENSE:                  <set to the key 'value' in secret 'tfe-license'>            Optional: false
      TFE_DATABASE_PASSWORD:        <set to the key 'value' in secret 'tfe-database-password'>  Optional: false
      TFE_REDIS_PASSWORD:           <set to the key 'value' in secret 'tfe-redis-password'>     Optional: false
```