### PR TITLE
Ensure tag pushes trigger `update-helm-charts-index` workflow

### DIFF
--- a/.github/workflows/create-or-update-tag.yml
+++ b/.github/workflows/create-or-update-tag.yml
@@ -36,9 +36,9 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          token: ${{ secrets.TFE_GITHUB_TOKEN }} 
       - name: Configure Git
         run: |
-          git config --global url.'https://${{ secrets.TFE_GITHUB_TOKEN }}:@github.com'.insteadOf 'https://github.com'
           git config --global user.email "team-tf-enterprise@hashicorp.com" && git config --global user.name "hc-tfe-release-bot"
       - name: Get Target SHA
         id: get_sha


### PR DESCRIPTION
## Description
This PR fixes the [update-helm-charts-index](https://github.com/hashicorp/terraform-enterprise-helm/actions/workflows/update-helm-charts-index.yml) workflow trigger by passing `TFE_GITHUB_TOKEN` directly to actions/checkout instead of relying on `url.insteadOf`.

Previously, `url.insteadOf` was ignored by git and the default `GITHUB_TOKEN` was used. While tag pushes succeeded, GitHub suppresses downstream workflow triggers for actions performed with `GITHUB_TOKEN`. Using `TFE_GITHUB_TOKEN` ensures the tag push correctly triggers the follow-up workflow.

## Testing
1. Release and Tag Created (I have deleted the Release and Tag after testing):
<img width="1164" height="773" alt="image" src="https://github.com/user-attachments/assets/a53b0575-9c07-4795-963c-572e858d8d26" />


2. [update-helm-charts-index](https://github.com/hashicorp/terraform-enterprise-helm/actions/runs/24770913836) workflow triggered:
<img width="1236" height="286" alt="image" src="https://github.com/user-attachments/assets/41fc3b9a-eb03-4cf2-b929-5bf2fb1366fb" />

