### PR TITLE
add container command and args override compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ The versions required are:
 
 Complete documentation and instructions for the installation of Terraform Enterprise can be found on the [Terraform Enterprise developer site](https://developer.hashicorp.com/terraform/enterprise/flexible-deployments/install).
 
+## Custom container startup overrides
+
+The chart supports optional `container.command` and `container.args` values to allow environment-specific startup customization.
+
+Be aware that setting `container.command` replaces the container image's default startup command. Terraform Enterprise normally starts through `/usr/local/bin/terraform-enterprise-run`. If you provide a custom wrapper script or command, it must end by exec'ing `/usr/local/bin/terraform-enterprise-run`, otherwise the normal Terraform Enterprise bootstrap and startup flow will be skipped.
+
 ## Helpful Commands
 There are a number of common helm or kubectl commands you can use to monitor the installation and the runtime of Terraform Enterprise. We list some of them here. We assume that the namespace is `terraform-enterprise`. If you have a different namespace, replace it with yours.
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -108,6 +108,14 @@ spec:
         {{ toYaml .Values.initContainers | nindent 8}}
       containers:
       - name: terraform-enterprise
+        {{- if .Values.container.command }}
+        command:
+          {{ .Values.container.command }}
+        {{- end }}
+        {{- if .Values.container.args }}
+        args:
+          {{ toYaml .Values.container.args | nindent 10}}
+        {{- end }}
         image: {{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -110,7 +110,7 @@ spec:
       - name: terraform-enterprise
         {{- if .Values.container.command }}
         command:
-          {{ .Values.container.command }}
+          {{ toYaml .Values.container.command | nindent 10 }}
         {{- end }}
         {{- if .Values.container.args }}
         args:

--- a/values.yaml
+++ b/values.yaml
@@ -35,6 +35,13 @@ pod:
 container:
 # Configure pod specific security context settings
   securityContext: {}
+  # Optional override for the container startup command.
+  # If set, this replaces the image default command.
+  # Custom wrappers must end by exec'ing /usr/local/bin/terraform-enterprise-run
+  # so the normal Terraform Enterprise bootstrap/startup path is preserved.
+  # command: []
+  # Optional args passed to the container command.
+  # args: []
 
 # The deployment's strategy is not set by default. This should be a YAML map corresponding to a
 # Kubernetes [DeploymentStrategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#deploymentstrategy-v1-apps) object.


### PR DESCRIPTION
## Summary

Make TFE container startup overrides optional and value-driven.

## Description

This change updates the chart so `container.command` and `container.args` are only rendered when explicitly provided. This preserves default startup behavior while allowing downstream consumers to inject environment-specific startup customization when needed.

## Background

Some environments require pre-start logic, but that logic should live in consumer values/scripts rather than being embedded in the chart.

Specifically, this change was originally motivated by a case on IBM Cloud Postgresql databases, where the startup wrapper needed to update the application database search path before Terraform Enterprise started, but the mechanism is generic and can support any similar pre-start customization.

### Example usage

One concrete use case is a platform that requires startup-time adjustments before Terraform Enterprise begins its normal boot process.

For example, a downstream deployment may need to:

- modify database-related application settings at runtime
- patch generated configuration files before services start
- adjust nginx parameters for environment-specific hostname or networking requirements

With this change, that logic can be supplied externally through chart values rather than embedded in the chart.

Example:

```
container:
  command:
    - /bin/sh
  args:
    - -c
    - /scripts/custom_tfe_start.sh

extraVolumes:
  - name: scripts
    configMap:
      name: custom-tfe-start
      defaultMode: 488

extraVolumeMounts:
  - name: scripts
    mountPath: /scripts
    readOnly: true
```

## Testing

Without override:

```
cat /app/config/database.yml | grep ibm_ext
# no output
```

With override:

```
cat /app/config/database.yml | grep ibm_ext
  schema_search_path: "public,ibm_extension"
  schema_search_path: "public,ibm_extension"
  schema_search_path: "public,ibm_extension"
```