### PR TITLE
fix: set default strategy to Recreate

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -38,11 +38,8 @@ container:
 
 # The deployment's strategy is not set by default. This should be a YAML map corresponding to a
 # Kubernetes [DeploymentStrategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#deploymentstrategy-v1-apps) object.
-# strategy:
-#   type: RollingUpdate
-#   rollingUpdate:
-#     maxSurge: 1
-#     maxUnavailable: 0
+strategy:
+  type: Recreate
 
 # Resource limits are not set by default, to give the user the ability to set specific resource limits.
 # If you do want to specify resource limits, uncomment the following lines and adjust them as necessary.


### PR DESCRIPTION
This pull request updates the deployment strategy for the container in the `values.yaml` configuration file. The deployment strategy has been changed from the default (commented-out) rolling update to an explicit `Recreate` strategy.

Deployment configuration changes:

* Set the deployment `strategy` to `Recreate` in `values.yaml`, replacing the previously commented-out `RollingUpdate` example.

# Background

Since TFE v2.0.0, live upgrade is forbidden since TFE startup checks avoid mixed versions in cluster.