### PR TITLE
adding the adminconsole ingress

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -44,4 +44,45 @@ spec:
           {{- end }}
     {{- end }}
 {{- end }}
+---
+{{- if .Values.ingressAdminConsole.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: terraform-enterprise-admin-console
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: terraform-enterprise
+  {{- with .Values.ingressAdminConsole.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingressAdminConsole.className }}
+  {{- if .Values.ingressAdminConsole.tls }}
+  tls:
+    {{- range .Values.ingressAdminConsole.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingressAdminConsole.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ .serviceName }}
+                port:
+                  number: {{ .portNumber }}
+          {{- end }}
+    {{- end }}
+{{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -212,6 +212,25 @@ ingress:
     #   hosts:
     #   - "*.ptfe-dev.aws.ptfedev.com"
 
+# ingressAdminConsole allows an ingress service to be created for the Terraform Enterprise
+# admin console, exposing it separately from the main application ingress.
+ingressAdminConsole:
+  enabled: false
+  className: "" # nginx
+  annotations: {}
+    # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+  hosts:
+    - host: "" # "*.ptfe-dev.aws.ptfedev.com"
+      paths:
+        - path: /
+          pathType: Prefix
+          serviceName: "terraform-enterprise"
+          portNumber: 8446
+  tls: []
+    # - secretName: terraform-enterprise-admin-console-certificates
+    #   hosts:
+    #   - "*.ptfe-dev.aws.ptfedev.com"
+
  # Injector service specific configurations
 service:
   annotations: {}


### PR DESCRIPTION
With the new admin console running on port 8446 for kubernetes/openshift the helm chart needs to support this for ingress controllers

Ingress controllers work on the hostname but have issues with ports for example. You will need to have an additional ingress rule for the specific port

added an extra value which is disabled by default for an `ingressAdminConsole`. Once enabled this can be used to have the adminconsole configured with the correct ingress rules

I tested this on AWS with the application load balancer and ingress controller from AWS. It is working

I added a second variable to make it easy and simple to add and configure and not make it complicated. It also gives customers the option to play with settings if needed. 