### PR TITLE
TF-34280: Add configurable readiness probe timing

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -148,6 +148,18 @@ spec:
             path: {{ .Values.tfe.readinessProbePath | default "/api/v1/health/readiness" }}
             port: {{ .Values.tfe.privateHttpPort }}
             scheme: {{ .Values.tfe.readinessProbeScheme | default "HTTP"  }}
+          {{- if .Values.tfe.readinessProbeInitialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.tfe.readinessProbeInitialDelaySeconds }}
+          {{- end }}
+          {{- if .Values.tfe.readinessProbePeriodSeconds }}
+          periodSeconds: {{ .Values.tfe.readinessProbePeriodSeconds }}
+          {{- end }}
+          {{- if .Values.tfe.readinessProbeFailureThreshold }}
+          failureThreshold: {{ .Values.tfe.readinessProbeFailureThreshold }}
+          {{- end }}
+          {{- if .Values.tfe.readinessProbeTimeoutSeconds }}
+          timeoutSeconds: {{ .Values.tfe.readinessProbeTimeoutSeconds }}
+          {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:

--- a/values.yaml
+++ b/values.yaml
@@ -106,12 +106,6 @@ tfe:
   ## Readiness probe settings customize the terraform-enterprise health check path, eg: to use the full service dependency check
   # readinessProbePath: "/_health_check?full"
   # readinessProbeScheme: "HTTP"
-  ## Readiness probe timing settings. Tune these to accommodate slow startup environments
-  ## (e.g. EKS with NLB provisioning delay or high SNAT contention).
-  ## initialDelaySeconds: seconds to wait before the first probe (default: 0)
-  ## periodSeconds: how often to probe (default: 10)
-  ## failureThreshold: consecutive failures before marking unready (default: 3)
-  ## timeoutSeconds: seconds before a probe times out (default: 1)
   # readinessProbeInitialDelaySeconds: 60
   # readinessProbePeriodSeconds: 10
   # readinessProbeFailureThreshold: 30

--- a/values.yaml
+++ b/values.yaml
@@ -106,6 +106,16 @@ tfe:
   ## Readiness probe settings customize the terraform-enterprise health check path, eg: to use the full service dependency check
   # readinessProbePath: "/_health_check?full"
   # readinessProbeScheme: "HTTP"
+  ## Readiness probe timing settings. Tune these to accommodate slow startup environments
+  ## (e.g. EKS with NLB provisioning delay or high SNAT contention).
+  ## initialDelaySeconds: seconds to wait before the first probe (default: 0)
+  ## periodSeconds: how often to probe (default: 10)
+  ## failureThreshold: consecutive failures before marking unready (default: 3)
+  ## timeoutSeconds: seconds before a probe times out (default: 1)
+  # readinessProbeInitialDelaySeconds: 60
+  # readinessProbePeriodSeconds: 10
+  # readinessProbeFailureThreshold: 30
+  # readinessProbeTimeoutSeconds: 5
 
 # nodeSelector labels for server pod assignment, formatted as a multi-line string or YAML map.
 nodeSelector: {}


### PR DESCRIPTION
## Summary

Adds optional readiness probe timing configuration to the TFE Helm chart. 

## New values (all optional, backwards-compatible)

```yaml
tfe:
  readinessProbeInitialDelaySeconds: 60  # default: 0
  readinessProbePeriodSeconds: 10        # default: 10
  readinessProbeFailureThreshold: 30     # default: 3
  readinessProbeTimeoutSeconds: 5        # default: 1
```

All fields are omitted from the rendered manifest when unset, preserving existing Kubernetes defaults. No breaking changes.

## References

TF-34280