### PR TITLE
Bump chart version to 1.6.8 and app version to 2.0.2

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -7,4 +7,4 @@ kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
 version: 1.6.8
-appVersion: "2.0.1"
+appVersion: "2.0.2"


### PR DESCRIPTION
Bumps `version` to `1.6.8` and `appVersion` to `2.0.2` in `Chart.yaml`.