### PR TITLE
Test Jira sync validation

### DIFF
--- a/.github/workflows/create-pr-review-jira-issue.yml
+++ b/.github/workflows/create-pr-review-jira-issue.yml
@@ -36,13 +36,42 @@ jobs:
       # event payload data and call Jira with the three required Jira secrets.
       - name: Search Jira for an existing PR review story
         id: search
-        uses: hashicorp/gh-action-jira-search@96aebbb9218932983bfbe6984e4c1e3ec3bf710e # v0.3.1
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-        with:
-          jql: 'project = "${{ inputs.project }}" AND labels = "${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}"'
+          JIRA_PROJECT: ${{ inputs.project }}
+          UNIQUE_LABEL: ${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          response_file="$(mktemp)"
+          trap 'rm -f "$response_file"' EXIT
+
+          search_payload="$(jq -n \
+            --arg project "$JIRA_PROJECT" \
+            --arg unique_label "$UNIQUE_LABEL" \
+            '{
+              jql: ("project = " + $project + " AND labels = \"" + $unique_label + "\""),
+              maxResults: 1,
+              fields: ["key"]
+            }')"
+
+          search_status="$(curl --silent --show-error --write-out '%{http_code}' \
+            --output "$response_file" \
+            --request POST \
+            --url "${JIRA_BASE_URL%/}/rest/api/3/search" \
+            --user "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
+            --header 'Accept: application/json' \
+            --header 'Content-Type: application/json' \
+            --data "$search_payload")"
+
+          if [[ "$search_status" != "200" ]]; then
+            echo "::error::Jira search failed with status ${search_status}."
+            exit 1
+          fi
+
+          echo "issue=$(jq -r '.issues[0].key // ""' "$response_file")" >> "$GITHUB_OUTPUT"
 
       - name: Build Jira summary
         if: ${{ steps.search.outputs.issue == '' }}

--- a/.github/workflows/validate-pr-review-jira.yml
+++ b/.github/workflows/validate-pr-review-jira.yml
@@ -1,0 +1,106 @@
+name: Validate PR Review Jira Story
+
+on:
+  push:
+    branches:
+      - kosy/jira-sync-test-pr
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: validate-pr-review-jira-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate-pr-review-jira-story:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Look up validation PR
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '')
+            const { owner, repo } = context.repo
+
+            const { data: pulls } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head: `${owner}:${branch}`,
+              base: 'kosy/jira-sync-test-base',
+            })
+
+            if (pulls.length !== 1) {
+              core.setFailed(`Expected exactly one open validation PR for ${branch}, found ${pulls.length}.`)
+              return
+            }
+
+            const pr = pulls[0]
+            core.setOutput('number', String(pr.number))
+            core.setOutput('title', pr.title)
+            core.setOutput('url', pr.html_url)
+            core.setOutput('author', pr.user.login)
+
+      - name: Search Jira for an existing PR review story
+        id: search
+        uses: hashicorp/gh-action-jira-search@96aebbb9218932983bfbe6984e4c1e3ec3bf710e # v0.3.1
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        with:
+          jql: 'project = "TF" AND labels = "${{ github.event.repository.name }}-pr-${{ steps.pr.outputs.number }}"'
+
+      - name: Build Jira summary
+        if: ${{ steps.search.outputs.issue == '' }}
+        id: summary
+        env:
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+        run: |
+          set -euo pipefail
+
+          summary_prefix="[PR Review] ${REPOSITORY_NAME} #${PR_NUMBER}: "
+          max_title_length=$((255 - ${#summary_prefix}))
+          summary_title="$PR_TITLE"
+
+          if (( ${#summary_title} > max_title_length )); then
+            summary_title="${summary_title:0:$((max_title_length - 3))}..."
+          fi
+
+          echo "value=${summary_prefix}${summary_title}" >> "$GITHUB_OUTPUT"
+
+      - name: Create Jira PR review story
+        if: ${{ steps.search.outputs.issue == '' }}
+        uses: hashicorp/gh-action-jira-create@84c84ad564106f548729912dbda38d66ef117bb7 # v0.3.0
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        with:
+          project: TF
+          issuetype: Story
+          summary: ${{ steps.summary.outputs.value }}
+          description: |
+            This story tracks PR review for a ready-for-review GitHub pull request.
+
+            Repository: ${{ github.repository }}
+            Pull request: #${{ steps.pr.outputs.number }} ${{ steps.pr.outputs.title }}
+            URL: ${{ steps.pr.outputs.url }}
+            Author: ${{ steps.pr.outputs.author }}
+          extraFields: |
+            {
+              "parent": { "key": "TF-36978" },
+              "labels": [
+                "github-pr-review",
+                "${{ github.event.repository.name }}-pr-${{ steps.pr.outputs.number }}"
+              ]
+            }
+
+      - name: Skip existing Jira PR review story
+        if: ${{ steps.search.outputs.issue != '' }}
+        run: echo "A Jira PR review story already exists for this pull request."

--- a/.github/workflows/validate-pr-review-jira.yml
+++ b/.github/workflows/validate-pr-review-jira.yml
@@ -44,6 +44,40 @@ jobs:
             core.setOutput('url', pr.html_url)
             core.setOutput('author', pr.user.login)
 
+      - name: Validate Jira secrets and authentication
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          missing=()
+          for secret_name in JIRA_BASE_URL JIRA_USER_EMAIL JIRA_API_TOKEN; do
+            if [[ -z "${!secret_name:-}" ]]; then
+              missing+=("$secret_name")
+            fi
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Missing required Jira secrets: ${missing[*]}"
+            exit 1
+          fi
+
+          auth_response_file="$(mktemp)"
+          trap 'rm -f "$auth_response_file"' EXIT
+
+          auth_status="$(curl --silent --show-error --write-out '%{http_code}' \
+            --output "$auth_response_file" \
+            --url "${JIRA_BASE_URL%/}/rest/api/3/myself" \
+            --user "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
+            --header 'Accept: application/json')"
+
+          if [[ "$auth_status" != "200" ]]; then
+            echo "::error::Jira authentication check failed with status ${auth_status}."
+            exit 1
+          fi
+
       - name: Search Jira for an existing PR review story
         id: search
         env:

--- a/.github/workflows/validate-pr-review-jira.yml
+++ b/.github/workflows/validate-pr-review-jira.yml
@@ -3,7 +3,7 @@ name: Validate PR Review Jira Story
 on:
   push:
     branches:
-      - kosy/jira-sync-test-pr
+      - kosy/jira-sync-test-pr*
 
 permissions:
   contents: read

--- a/.github/workflows/validate-pr-review-jira.yml
+++ b/.github/workflows/validate-pr-review-jira.yml
@@ -149,10 +149,12 @@ jobs:
           description: |
             This story tracks PR review for a ready-for-review GitHub pull request.
 
-            Repository: ${{ github.repository }}
-            Pull request: #${{ steps.pr.outputs.number }} ${{ steps.pr.outputs.title }}
-            URL: ${{ steps.pr.outputs.url }}
-            Author: ${{ steps.pr.outputs.author }}
+            ### Pull Request Details
+
+            - **Repository:** ${{ github.repository }}
+            - **Pull request:** #${{ steps.pr.outputs.number }} ${{ steps.pr.outputs.title }}
+            - **URL:** ${{ steps.pr.outputs.url }}
+            - **Author:** ${{ steps.pr.outputs.author }}
           extraFields: |
             {
               "parent": { "key": "TF-36978" },

--- a/.github/workflows/validate-pr-review-jira.yml
+++ b/.github/workflows/validate-pr-review-jira.yml
@@ -102,7 +102,7 @@ jobs:
           search_status="$(curl --silent --show-error --write-out '%{http_code}' \
             --output "$response_file" \
             --request POST \
-            --url "${JIRA_BASE_URL%/}/rest/api/3/search" \
+            --url "${JIRA_BASE_URL%/}/rest/api/3/search/jql" \
             --user "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
             --header 'Accept: application/json' \
             --header 'Content-Type: application/json' \

--- a/.github/workflows/validate-pr-review-jira.yml
+++ b/.github/workflows/validate-pr-review-jira.yml
@@ -46,13 +46,40 @@ jobs:
 
       - name: Search Jira for an existing PR review story
         id: search
-        uses: hashicorp/gh-action-jira-search@96aebbb9218932983bfbe6984e4c1e3ec3bf710e # v0.3.1
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-        with:
-          jql: 'project = "TF" AND labels = "${{ github.event.repository.name }}-pr-${{ steps.pr.outputs.number }}"'
+          UNIQUE_LABEL: ${{ github.event.repository.name }}-pr-${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+
+          response_file="$(mktemp)"
+          trap 'rm -f "$response_file"' EXIT
+
+          search_payload="$(jq -n \
+            --arg unique_label "$UNIQUE_LABEL" \
+            '{
+              jql: ("project = TF AND labels = \"" + $unique_label + "\""),
+              maxResults: 1,
+              fields: ["key"]
+            }')"
+
+          search_status="$(curl --silent --show-error --write-out '%{http_code}' \
+            --output "$response_file" \
+            --request POST \
+            --url "${JIRA_BASE_URL%/}/rest/api/3/search" \
+            --user "$JIRA_USER_EMAIL:$JIRA_API_TOKEN" \
+            --header 'Accept: application/json' \
+            --header 'Content-Type: application/json' \
+            --data "$search_payload")"
+
+          if [[ "$search_status" != "200" ]]; then
+            echo "::error::Jira search failed with status ${search_status}."
+            exit 1
+          fi
+
+          echo "issue=$(jq -r '.issues[0].key // ""' "$response_file")" >> "$GITHUB_OUTPUT"
 
       - name: Build Jira summary
         if: ${{ steps.search.outputs.issue == '' }}


### PR DESCRIPTION
## Summary
- create a temporary PR to validate the Jira review-story automation before merging it to main
- uses an empty commit so the PR only exercises the workflow path

## Notes
- this PR is expected to create a Jira Story under TF-36978
- both the PR and the Jira story can be cleaned up after validation