### PR TITLE
Skip Jira automation for configured PR authors

### DIFF
--- a/.github/workflows/call-create-pr-review-jira-issue.yml
+++ b/.github/workflows/call-create-pr-review-jira-issue.yml
@@ -12,7 +12,14 @@ permissions:
 
 jobs:
   call-workflow:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: >-
+      ${{
+        github.event.pull_request.draft == false &&
+        !contains(
+          fromJSON(vars.JIRA_PR_SKIP_AUTHORS_JSON || '[]'),
+          github.event.pull_request.user.login
+        )
+      }}
     uses: ./.github/workflows/create-pr-review-jira-issue.yml
     with:
       project: TF


### PR DESCRIPTION
## Summary

Update the PR-opened Jira automation workflow to skip creating Jira stories for PR authors listed in the `JIRA_PR_SKIP_AUTHORS_JSON` Actions variable. The workflow now checks the PR author's GitHub username before calling the reusable Jira workflow.

## Background

The repository currently creates a Jira story for every non-draft PR open, reopen, and ready-for-review event. This change adds a simple opt-out for team-owned PRs without introducing extra tokens or an org membership lookup.

## Helm Chart Impact

Architecture impact:
No Helm chart architecture impact. This change only updates a GitHub Actions workflow gate in the repository.

Rendered resource / operational / security impact:
No rendered Kubernetes resource, chart default, or upgrade behavior impact. Operational impact is limited to GitHub Actions behavior: the Jira creation workflow will be skipped when `github.event.pull_request.user.login` is present in `JIRA_PR_SKIP_AUTHORS_JSON`.

## Testing

Validated the workflow YAML parses successfully with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/call-create-pr-review-jira-issue.yml")'`.
Reviewed the GitHub Actions expression against the intended variable format, for example `[`"teammate-one"`,`"teammate-two"`]`.
Gap: no local GitHub Actions runtime validation for the `pull_request_target` event path.

## Reviewer Notes

After merge, create a repository or organization Actions variable named `JIRA_PR_SKIP_AUTHORS_JSON` with a JSON array of GitHub usernames, for example `[`"teammate-one"`,`"teammate-two"`]`.
Non-goal: dynamic GitHub team membership lookup. This PR intentionally uses a static username list to avoid additional tokens or org membership API calls.
Rollback is a standard PR revert; no extra operational steps are expected.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
