### PR TITLE
feat(secrets): support 'b64:' prefix for pre-encoded env.secrets

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -76,11 +76,17 @@ Prints the key-value pair from the 'env.variables' entry in the Values file.
 
 {{/*
 Prints the key-value pair from the 'env.secrets' entry in the Values file
-and base64 encodes the value.
+and base64 encodes the value. If the value starts with 'b64:', it is treated
+as already base64-encoded and the prefix is stripped (useful for passing
+secrets through tooling that mangles raw special characters, e.g. Helm --set).
 */}}
 {{- define "helpers.list-env-secrets" }}
 {{- range $key, $val := .Values.env.secrets }}
+{{- if hasPrefix "b64:" $val }}
+{{ $key }}: {{ $val | trimPrefix "b64:" }}
+{{- else }}
 {{ $key }}: {{ trim $val | b64enc }}
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Summary

`helpers.list-env-secrets` base64-encodes every `env.secrets` value via `trim | b64enc`. When a secret value is supplied through tooling that mangles raw special characters — most notably Helm `--set` / ArgoCD Application `helm.parameters`, which interpret `, { [ } ] =` as structure — the value can be corrupted before it ever reaches the chart.

This adds an opt-in escape hatch: if a value is prefixed with `b64:`, it is treated as **already base64-encoded**. The prefix is stripped and the encoded value is used verbatim; otherwise the existing `trim | b64enc` behavior is unchanged.

```gotemplate
{{- range $key, $val := .Values.env.secrets }}
{{- if hasPrefix "b64:" $val }}
{{ $key }}: {{ $val | trimPrefix "b64:" }}
{{- else }}
{{ $key }}: {{ trim $val | b64enc }}
{{- end }}
{{- end }}
```

## Motivation

CI deploys TFE via an ArgoCD Application and passes DB/encryption passwords as Helm parameters. Random passwords containing `{ [ ,` break `--set` parsing. Pre-encoding to `b64:<base64>` (an alphanumeric+`/=` string) sidesteps the escaping entirely. This helper already exists on the `test-bg` branch; this PR brings it to `main`.

## Backward compatibility

Fully backward compatible — values without the `b64:` prefix behave exactly as before.

## Testing

```
helm template tfe . --show-only templates/secret.yaml \
  --set 'env.secrets.RAW_PASS=p@ssword' \
  --set 'env.secrets.PREENC_PASS=b64:aGVsbG8='
# PREENC_PASS decodes to 'hello' (prefix stripped, verbatim)
# RAW_PASS   decodes to 'p@ssword' (encoded by the chart as before)
```