### PR TITLE
Update appVersion to 2.0.4

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 1.6.9
-appVersion: "2.0.3"
+version: 1.6.8
+appVersion: "2.0.4"


### PR DESCRIPTION
## Summary

Updates the Helm chart for Terraform Enterprise.

## Changes
- `appVersion`: 2.0.3 -> 2.0.4
- `version`: 1.6.9 -> 1.6.8