### PR TITLE
Update appVersion to 2.0.4 (release/2.0.x)

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -7,4 +7,4 @@ kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
 version: 1.6.8
-appVersion: "2.0.2"
+appVersion: "2.0.4"


### PR DESCRIPTION
## Summary

Backports the Helm chart appVersion bump to the `release/2.0.x` branch.

## Changes
- `appVersion`: 2.0.2 -> 2.0.4

## Reference
- Backport of #196