### PR TITLE
version has be to updated to bigger than the most recent one 

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 1.6.8
+version: 1.6.10
 appVersion: "1.2.4"


### PR DESCRIPTION
## Summary
version has be to updated to bigger than the most recent one  since older version is not triggering the update even if it bigger within the branch

<!-- What changed in 1-3 sentences? -->

## Background
The helm chart ci didn't trigger because the version of the latest tag was bigger. 

<!-- Why is this change needed? Link issues, incidents, or prior PRs if helpful. -->

## Helm Chart Impact
Creates a new release for TFE release 1.2.4
Architecture impact:
<!-- Does this PR make a substantial change to the Helm chart architecture? If yes, describe. -->
None
Rendered resource / operational / security impact:
<!-- Does this PR change rendered Kubernetes resources, chart defaults, upgrade/rollback behavior, or security-sensitive areas such as RBAC, secrets, ingress/networking, storage, or availability? If yes, describe. -->

## Testing
Not required, will be validated from the workflows once the PR is merged. 

<!-- How has this been tested? Include commands, values files, environment/cluster details, manual verification, and any gaps. -->
<!-- Suggested validation:
- helm lint .
- helm template . | ./kubeconform --strict
-->

## Reviewer Notes

<!-- Point reviewers to tricky areas, non-goals, or follow-up work. -->

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
