### PR TITLE
docs(example): IBM Cloud values example with PostgreSQL extension initContainer (TF-38200)

### DIFF
--- a/docs/example/ibm-cloud-values.yaml
+++ b/docs/example/ibm-cloud-values.yaml
@@ -2,12 +2,13 @@
 #
 # IBM Cloud only allows PostgreSQL extensions in the `ibm_extension` schema and TFE
 # cannot create them itself, so the init container below creates them before TFE
-# starts, and TFE_DATABASE_EXTRA_SCHEMAS points TFE at that schema. See the
-# connect-database docs for the full explanation. Replace the placeholder values.
+# starts. TFE_DATABASE_EXTRA_SCHEMAS only tells TFE where to find them, it does not
+# create them, so both pieces are required. See the connect-database docs for details.
+# Replace the placeholder values.
 
 image:
-  repository: cp.icr.io/cp/ibm-terraform
-  name: ibm-terraform
+  repository: images.releases.hashicorp.com
+  name: hashicorp/terraform-enterprise
   tag: "2.0.5"
 
 env:
@@ -28,11 +29,11 @@ env:
     TFE_LICENSE: <your-license>
     TFE_DATABASE_PASSWORD: <your-icd-password>
 
-# Create the required extensions before TFE starts. Reuses the TFE image (it has psql);
-# keep this image tag in sync with image.tag above.
+# Create the required extensions before TFE starts. Use the same TFE image as above
+# (it includes psql), so no separate image is needed.
 initContainers:
   - name: create-pg-extensions
-    image: cp.icr.io/cp/ibm-terraform/ibm-terraform:2.0.5
+    image: images.releases.hashicorp.com/hashicorp/terraform-enterprise:2.0.5
     command: ["/bin/sh", "-c"]
     args:
       - >

--- a/docs/example/ibm-cloud-values.yaml
+++ b/docs/example/ibm-cloud-values.yaml
@@ -6,6 +6,7 @@
 # create them, so both pieces are required. See the connect-database docs for details.
 # Replace the placeholder values.
 
+# On IBM Cloud catalog deployments, use the entitled image cp.icr.io/cp/ibm-terraform/ibm-terraform instead.
 image:
   repository: images.releases.hashicorp.com
   name: hashicorp/terraform-enterprise

--- a/docs/example/ibm-cloud-values.yaml
+++ b/docs/example/ibm-cloud-values.yaml
@@ -1,24 +1,9 @@
-# Example values for Terraform Enterprise on IBM Cloud with IBM Cloud Databases
-# for PostgreSQL.
+# Terraform Enterprise on IBM Cloud with IBM Cloud Databases for PostgreSQL.
 #
-# Problem this solves:
-# IBM Cloud Databases for PostgreSQL only allows extensions to be installed into
-# a dedicated `ibm_extension` schema, and Terraform Enterprise cannot create them
-# there itself. Without help, Terraform Enterprise fails to start with a
-# "missing required extensions" error.
-#
-# This example automates the fix with the chart's existing initContainers
-# passthrough, so it needs no chart change:
-#   1. An init container creates the required extensions before Terraform
-#      Enterprise starts. It reuses the Terraform Enterprise image, which already
-#      ships psql, so no extra image needs mirroring for air-gapped installs, and
-#      it reads the database connection from the chart's own env config and
-#      secret, so it needs no separate credential.
-#   2. TFE_DATABASE_EXTRA_SCHEMAS=ibm_extension puts that schema on the search
-#      path so Terraform Enterprise finds the extensions.
-#
-# The extension-creation step was verified against IBM Cloud Databases for
-# PostgreSQL on 2026-07-07 (TF-38200). Replace the placeholder values below.
+# IBM Cloud only allows PostgreSQL extensions in the `ibm_extension` schema and TFE
+# cannot create them itself, so the init container below creates them before TFE
+# starts, and TFE_DATABASE_EXTRA_SCHEMAS points TFE at that schema. See the
+# connect-database docs for the full explanation. Replace the placeholder values.
 
 image:
   repository: cp.icr.io/cp/ibm-terraform
@@ -30,14 +15,12 @@ env:
     TFE_HOSTNAME: <your-tfe-hostname>
     TFE_OPERATIONAL_MODE: external
 
-    # IBM Cloud Databases for PostgreSQL connection.
     TFE_DATABASE_HOST: <your-icd-host>:<port>
     TFE_DATABASE_NAME: ibmclouddb
     TFE_DATABASE_USER: admin
     TFE_DATABASE_PARAMETERS: sslmode=require
 
-    # Put the ibm_extension schema on the search path so Terraform Enterprise
-    # finds the extensions the init container creates.
+    # where the init container creates the extensions
     TFE_DATABASE_EXTRA_SCHEMAS: ibm_extension
 
   secrets:
@@ -45,9 +28,8 @@ env:
     TFE_LICENSE: <your-license>
     TFE_DATABASE_PASSWORD: <your-icd-password>
 
-# Create the required PostgreSQL extensions before Terraform Enterprise starts.
-# Keep this image in sync with image.* above. It reuses the Terraform Enterprise
-# image because that image already includes psql.
+# Create the required extensions before TFE starts. Reuses the TFE image (it has psql);
+# keep this image tag in sync with image.tag above.
 initContainers:
   - name: create-pg-extensions
     image: cp.icr.io/cp/ibm-terraform/ibm-terraform:2.0.5

--- a/docs/example/ibm-cloud-values.yaml
+++ b/docs/example/ibm-cloud-values.yaml
@@ -29,8 +29,9 @@ env:
     TFE_LICENSE: <your-license>
     TFE_DATABASE_PASSWORD: <your-icd-password>
 
-# Create the required extensions before TFE starts. Use the same TFE image as above
-# (it includes psql), so no separate image is needed.
+# Optional automation: this init container creates the extensions before TFE starts so
+# operators do not have to. You can also create them manually before install (see docs).
+# Use the same TFE image as above; it includes psql, so no separate image is needed.
 initContainers:
   - name: create-pg-extensions
     image: images.releases.hashicorp.com/hashicorp/terraform-enterprise:2.0.5

--- a/docs/example/ibm-cloud-values.yaml
+++ b/docs/example/ibm-cloud-values.yaml
@@ -10,7 +10,7 @@
 image:
   repository: images.releases.hashicorp.com
   name: hashicorp/terraform-enterprise
-  tag: "2.0.5"
+  tag: "2.0.4"
 
 env:
   variables:
@@ -35,7 +35,7 @@ env:
 # Use the same TFE image as above; it includes psql, so no separate image is needed.
 initContainers:
   - name: create-pg-extensions
-    image: images.releases.hashicorp.com/hashicorp/terraform-enterprise:2.0.5
+    image: images.releases.hashicorp.com/hashicorp/terraform-enterprise:2.0.4
     command: ["/bin/sh", "-c"]
     args:
       - >

--- a/docs/example/ibm-cloud-values.yaml
+++ b/docs/example/ibm-cloud-values.yaml
@@ -1,0 +1,67 @@
+# Example values for Terraform Enterprise on IBM Cloud with IBM Cloud Databases
+# for PostgreSQL.
+#
+# Problem this solves:
+# IBM Cloud Databases for PostgreSQL only allows extensions to be installed into
+# a dedicated `ibm_extension` schema, and Terraform Enterprise cannot create them
+# there itself. Without help, Terraform Enterprise fails to start with a
+# "missing required extensions" error.
+#
+# This example automates the fix with the chart's existing initContainers
+# passthrough, so it needs no chart change:
+#   1. An init container creates the required extensions before Terraform
+#      Enterprise starts. It reuses the Terraform Enterprise image, which already
+#      ships psql, so no extra image needs mirroring for air-gapped installs, and
+#      it reads the database connection from the chart's own env config and
+#      secret, so it needs no separate credential.
+#   2. TFE_DATABASE_EXTRA_SCHEMAS=ibm_extension puts that schema on the search
+#      path so Terraform Enterprise finds the extensions.
+#
+# The extension-creation step was verified against IBM Cloud Databases for
+# PostgreSQL on 2026-07-07 (TF-38200). Replace the placeholder values below.
+
+image:
+  repository: cp.icr.io/cp/ibm-terraform
+  name: ibm-terraform
+  tag: "2.0.5"
+
+env:
+  variables:
+    TFE_HOSTNAME: <your-tfe-hostname>
+    TFE_OPERATIONAL_MODE: external
+
+    # IBM Cloud Databases for PostgreSQL connection.
+    TFE_DATABASE_HOST: <your-icd-host>:<port>
+    TFE_DATABASE_NAME: ibmclouddb
+    TFE_DATABASE_USER: admin
+    TFE_DATABASE_PARAMETERS: sslmode=require
+
+    # Put the ibm_extension schema on the search path so Terraform Enterprise
+    # finds the extensions the init container creates.
+    TFE_DATABASE_EXTRA_SCHEMAS: ibm_extension
+
+  secrets:
+    TFE_ENCRYPTION_PASSWORD: <your-encryption-password>
+    TFE_LICENSE: <your-license>
+    TFE_DATABASE_PASSWORD: <your-icd-password>
+
+# Create the required PostgreSQL extensions before Terraform Enterprise starts.
+# Keep this image in sync with image.* above. It reuses the Terraform Enterprise
+# image because that image already includes psql.
+initContainers:
+  - name: create-pg-extensions
+    image: cp.icr.io/cp/ibm-terraform/ibm-terraform:2.0.5
+    command: ["/bin/sh", "-c"]
+    args:
+      - >
+        PGSSLMODE=require PGPASSWORD="$TFE_DATABASE_PASSWORD"
+        psql -h "${TFE_DATABASE_HOST%%:*}" -p "${TFE_DATABASE_HOST##*:}"
+        -U "$TFE_DATABASE_USER" -d "$TFE_DATABASE_NAME"
+        -c 'CREATE EXTENSION IF NOT EXISTS hstore;'
+        -c 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp";'
+        -c 'CREATE EXTENSION IF NOT EXISTS citext;'
+    envFrom:
+      - configMapRef:
+          name: terraform-enterprise-env-config
+      - secretRef:
+          name: terraform-enterprise-env-secrets

--- a/docs/example/ibm-cloud-values.yaml
+++ b/docs/example/ibm-cloud-values.yaml
@@ -1,12 +1,23 @@
-# Terraform Enterprise on IBM Cloud with IBM Cloud Databases for PostgreSQL.
-#
-# IBM Cloud only allows PostgreSQL extensions in the `ibm_extension` schema and TFE
-# cannot create them itself, so the init container below creates them before TFE
-# starts. TFE_DATABASE_EXTRA_SCHEMAS only tells TFE where to find them, it does not
-# create them, so both pieces are required. See the connect-database docs for details.
-# Replace the placeholder values.
+# Copyright IBM Corp. 2026
+# SPDX-License-Identifier: MPL-2.0
 
-# On IBM Cloud catalog deployments, use the entitled image cp.icr.io/cp/ibm-terraform/ibm-terraform instead.
+# Terraform Enterprise on IBM Cloud — IBM Cloud Databases for PostgreSQL overlay.
+#
+# This is an OVERLAY file. Apply it on top of a complete base values file that
+# supplies all required configuration (TLS, object storage, Redis, etc.). For example:
+#
+#   helm install terraform-enterprise . \
+#     -f base-values.yaml \
+#     -f docs/example/ibm-cloud-values.yaml
+#
+# IBM Cloud Databases for PostgreSQL only allows PostgreSQL extensions in the
+# `ibm_extension` schema. TFE cannot create them itself, so the init container below
+# creates them before TFE starts. TFE_DATABASE_EXTRA_SCHEMAS tells TFE where to find
+# the extensions; it does not create them. Both pieces are required. See the
+# connect-database docs for details.
+
+# On IBM Cloud catalog deployments, use the entitled image
+# cp.icr.io/cp/ibm-terraform/ibm-terraform instead.
 image:
   repository: images.releases.hashicorp.com
   name: hashicorp/terraform-enterprise
@@ -17,24 +28,49 @@ env:
     TFE_HOSTNAME: <your-tfe-hostname>
     TFE_OPERATIONAL_MODE: external
 
+    # TFE_DATABASE_HOST must be in host:port format. The init container uses
+    # shell parameter expansion to split the two, so a host-only value will
+    # produce an invalid psql -p argument and the init container will fail.
     TFE_DATABASE_HOST: <your-icd-host>:<port>
     TFE_DATABASE_NAME: ibmclouddb
     TFE_DATABASE_USER: admin
     TFE_DATABASE_PARAMETERS: sslmode=require
 
-    # where the init container creates the extensions
+    # TFE_DATABASE_EXTRA_SCHEMAS tells TFE where to find the extensions.
+    # The init container below is what actually creates them in this schema.
     TFE_DATABASE_EXTRA_SCHEMAS: ibm_extension
+
+    # Object storage — required; add the keys that match your storage backend.
+    # TFE_OBJECT_STORAGE_TYPE: <s3|azure|google>
+    # TFE_OBJECT_STORAGE_S3_BUCKET: <your-cos-bucket>
+    # TFE_OBJECT_STORAGE_S3_ENDPOINT: <your-cos-endpoint>
+    # TFE_OBJECT_STORAGE_S3_REGION: <your-cos-region>
+    # TFE_OBJECT_STORAGE_S3_ACCESS_KEY_ID: <your-cos-access-key-id>
+
+    # Redis — required when TFE_OPERATIONAL_MODE is active-active.
+    # TFE_REDIS_HOST: <your-redis-host>:<port>
 
   secrets:
     TFE_ENCRYPTION_PASSWORD: <your-encryption-password>
     TFE_LICENSE: <your-license>
     TFE_DATABASE_PASSWORD: <your-icd-password>
+    # TFE_OBJECT_STORAGE_S3_SECRET_ACCESS_KEY: <your-cos-secret-key>
 
-# Optional automation: this init container creates the extensions before TFE starts so
-# operators do not have to. You can also create them manually before install (see docs).
-# Use the same TFE image as above; it includes psql, so no separate image is needed.
+# TLS — required. Either supply cert/key data inline or reference a pre-created
+# Kubernetes secret. See the chart values docs for tls.certData / tls.certificateSecret.
+# tls:
+#   certificateSecret: <your-tls-secret-name>
+
+# Optional automation: this init container creates the extensions before TFE starts.
+# You can also create them manually before install (see docs).
+#
+# The init container uses the same image as TFE above; it ships psql, so no separate
+# image needs to be mirrored for air-gapped installs. Keep the image reference below
+# in sync with the image.repository/name/tag above, including any private registry
+# prefix (e.g. cp.icr.io/cp/ibm-terraform/ibm-terraform:<tag> for IBM catalog installs).
 initContainers:
   - name: create-pg-extensions
+    # Keep in sync with image.repository/name/tag above.
     image: images.releases.hashicorp.com/hashicorp/terraform-enterprise:2.0.4
     command: ["/bin/sh", "-c"]
     args:

--- a/docs/example/ibm-cloud-values.yaml
+++ b/docs/example/ibm-cloud-values.yaml
@@ -16,8 +16,24 @@
 # the extensions; it does not create them. Both pieces are required. See the
 # connect-database docs for details.
 
-# On IBM Cloud catalog deployments, use the entitled image
-# cp.icr.io/cp/ibm-terraform/ibm-terraform instead.
+# Choose the image source that matches your deployment path:
+#
+# Standard (images.releases.hashicorp.com):
+#   image:
+#     repository: images.releases.hashicorp.com
+#     name: hashicorp/terraform-enterprise
+#     tag: "2.0.4"
+#
+# IBM Cloud catalog / entitled registry (cp.icr.io):
+#   image:
+#     repository: cp.icr.io/cp/ibm-terraform
+#     name: ibm-terraform
+#     tag: "2.0.4"
+#   imagePullSecrets:
+#     - name: <your-ibm-entitlement-pull-secret>
+#
+# Uncomment and fill in whichever block applies. The init container image below
+# must use the same registry, name, and tag.
 image:
   repository: images.releases.hashicorp.com
   name: hashicorp/terraform-enterprise
@@ -64,14 +80,16 @@ env:
 # Optional automation: this init container creates the extensions before TFE starts.
 # You can also create them manually before install (see docs).
 #
-# The init container uses the same image as TFE above; it ships psql, so no separate
-# image needs to be mirrored for air-gapped installs. Keep the image reference below
-# in sync with the image.repository/name/tag above, including any private registry
-# prefix (e.g. cp.icr.io/cp/ibm-terraform/ibm-terraform:<tag> for IBM catalog installs).
+# The init container uses the TFE image (it ships psql), so no separate image needs
+# to be mirrored for air-gapped installs. The image here MUST match the image block
+# above — same registry, name, and tag — or the init container will pull from a
+# different source and fail in restricted-network environments.
+#
+# Standard:  images.releases.hashicorp.com/hashicorp/terraform-enterprise:2.0.4
+# IBM catalog: cp.icr.io/cp/ibm-terraform/ibm-terraform:2.0.4
 initContainers:
   - name: create-pg-extensions
-    # Keep in sync with image.repository/name/tag above.
-    image: images.releases.hashicorp.com/hashicorp/terraform-enterprise:2.0.4
+    image: images.releases.hashicorp.com/hashicorp/terraform-enterprise:2.0.4  # update if using IBM catalog
     command: ["/bin/sh", "-c"]
     args:
       - >


### PR DESCRIPTION
CHANGELOG:

no-impact

## Summary

Adds `docs/example/ibm-cloud-values.yaml`, an **overlay** values file for Terraform Enterprise on IBM Cloud with IBM Cloud Databases for PostgreSQL. It documents the PostgreSQL extension workaround using the chart's existing `initContainers` passthrough — no chart changes.

## Background

IBM Cloud Databases for PostgreSQL only allows extensions in a dedicated `ibm_extension` schema. TFE cannot create them there itself, so it fails to start with a `missing required extensions` error. The overlay shows the supported fix: an init container creates `hstore`, `uuid-ossp`, and `citext` before TFE starts, and `TFE_DATABASE_EXTRA_SCHEMAS=ibm_extension` puts that schema on the search path.

Related: TF-38200. Companion docs update: hashicorp/web-unified-docs-internal#1811.

## Helm Chart Impact

Architecture impact: None — no chart templates or default values change.

Rendered resource / operational / security impact: None. This is a documentation-only addition.

## Testing

- `helm template . -f docs/example/ibm-cloud-values.yaml` (on top of a base values file) renders the init container into the Deployment with no errors.
- The extension-creation step was verified against a real IBM Cloud Databases for PostgreSQL instance on 2026-07-07: extensions started absent, were created by the init container, and landed in `ibm_extension`.

## Reviewer Notes

This is an overlay file, not a standalone install values file. The header now makes that explicit with a usage example. Required config that operators must supply in their base file (TLS, object storage, Redis) is called out as commented stubs.

The init container image is intentionally hardcoded to match `image.tag` above — a comment notes it must be kept in sync, including for IBM catalog (`cp.icr.io/...`) deployments.

`TFE_DATABASE_HOST` must be `host:port`; the shell expansion used to split host and port will silently produce an invalid `psql -p` argument if the port is omitted, so this is now documented on the placeholder line.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.