### PR TITLE
docs: replace deprecated health check endpoint

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -125,7 +125,7 @@ We need to establish communication with Terraform Enterprise to continue. This w
 
 * Installing the included CA certificate into your local CA certificates or key store
 * Creating a host file entry for the load balancer for Terraform Enterprise
-* Testing your connection to Terraform Enterprise by inspecting the `_health_check` endpoint of Terraform Enterprise with `curl`
+* Testing your connection to Terraform Enterprise by inspecting the readiness endpoint with `curl`
 * Creating an administrative account and authenticating to Terraform Enterprise in the browser.
 
 Feel free to generate a new TLS key set and a CA certificate if you do not wish to install the included CA certificate. Alternatively, you could execute this configuration and testing procedure inside an isolated virtual machine.
@@ -156,8 +156,8 @@ Now add a host file entry on your workstation for this external ip address:
 
 and validate this address with curl:
 ```shell
-> curl https://terraform-enterprise.terraform-enterprise.svc.cluster.local/_health_check
-OK
+> curl --fail --silent --output /dev/null --write-out '%{http_code}\n' https://terraform-enterprise.terraform-enterprise.svc.cluster.local/api/v1/health/readiness
+200
 ```
 
 ## Test Drive Terraform Enterprise!

--- a/values.yaml
+++ b/values.yaml
@@ -103,8 +103,8 @@ tfe:
   privateHttpsPort: 8443
   # Specifies the port that the system API endpoints listen on for HTTPS requests.
   adminHttpsPort: 8446
-  ## Readiness probe settings customize the terraform-enterprise health check path, eg: to use the full service dependency check
-  # readinessProbePath: "/_health_check?full"
+  ## Readiness probe settings customize the Terraform Enterprise readiness endpoint.
+  # readinessProbePath: "/api/v1/health/readiness"
   # readinessProbeScheme: "HTTP"
   # readinessProbeInitialDelaySeconds: 60
   # readinessProbePeriodSeconds: 10
@@ -224,7 +224,7 @@ service:
     # - For Google Cloud, use the NEG (Network Endpoint Group) annotation:
     #   cloud.google.com/neg: '{"ingress": true}'
     # - For Azure, configure the health probe request path for HTTPS health checks:
-    #   service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/_health_check"
+    #   service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/api/v1/health/readiness"
   labels: {}
     # Add labels to the service created for Terraform Enterprise. Helpful if your metrics collection
     # depends on ServiceMonitors instead of pod annotations.
@@ -256,7 +256,7 @@ serviceSecondary:
     # - For Google Cloud, use the NEG (Network Endpoint Group) annotation:
     #   cloud.google.com/neg: '{"ingress": true}'
     # - For Azure, configure the health probe request path for HTTPS health checks:
-    #   service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/_health_check"
+    #   service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/api/v1/health/readiness"
   labels: {}
     # Add labels to the service created for Terraform Enterprise. Helpful if your metrics collection
     # depends on ServiceMonitors instead of pod annotations.


### PR DESCRIPTION
CHANGELOG:

- Update readiness probe examples and quickstart guidance to use `/api/v1/health/readiness` instead of the removed `/_health_check` endpoint.

## Summary

Updates all remaining `/_health_check` references in `values.yaml` and the quickstart to use the supported Terraform Enterprise readiness endpoint at `/api/v1/health/readiness`. The quickstart curl example now explicitly verifies the expected HTTP 200 response.

## Background

Terraform Enterprise deprecated `/_health_check` in version 1.2.0 and has since removed it; requests now return HTTP 410 Gone. Although the chart deployment template already defaults its Kubernetes readiness probe to `/api/v1/health/readiness`, the sample readiness override, Azure load balancer annotations, and quickstart still directed operators to the removed endpoint.

Keeping these examples aligned prevents new installations and copied configurations from receiving HTTP 410 responses or reporting nodes as unhealthy.

## Helm Chart Impact

Architecture impact:
None.

Rendered resource / operational / security impact:
No chart default or template behavior changes. Operators who copy the updated sample values will configure readiness checks against the supported endpoint. Existing user-supplied values are not modified. No security controls are affected.

## Testing

- `helm lint .`
- `helm template . | kubeconform --strict`
- Rendered the default deployment and confirmed the readiness path is `/api/v1/health/readiness`.
- Rendered with `--set-string tfe.readinessProbePath=/custom/readiness` and confirmed custom overrides remain supported.
- `git diff --check`

## Reviewer Notes

The deployment template itself already uses the new endpoint, so this PR intentionally changes only stale examples and documentation. Reverting requires only reverting this PR; there is no state or data migration.

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.
