### PR TITLE
Make primary certificates volume and mounts optional via tls.enabled

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -59,9 +59,11 @@ spec:
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
       volumes:
+        {{- if ne .Values.tls.enabled false }}
         - name: certificates
           secret:
             secretName: {{ .Values.tls.certificateSecret }}
+        {{- end }}
         {{- if or (and .Values.tlsSecondary.certData .Values.tlsSecondary.keyData) .Values.tlsSecondary.certificateSecret }}
         - name: certificates-secondary
           secret:
@@ -170,13 +172,15 @@ spec:
           - name: certificates-secondary
             mountPath: {{ .Values.tlsSecondary.keyMountPath }}
             subPath: tls.key        
-          {{- end }}  
+          {{- end }}
+          {{- if ne .Values.tls.enabled false }}
           - name: certificates
             mountPath: {{ .Values.tls.certMountPath }}
             subPath: tls.crt
           - name: certificates
             mountPath: {{ .Values.tls.keyMountPath }}
             subPath: tls.key
+          {{- end }}
           {{- if .Values.tls.caCertData }}
           - name: ca-certificates
             mountPath: {{ include "cacert.path" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -61,8 +61,9 @@ resources:
 # secrets management system. The values given below are for testing purposes only.
 tls:
   # Defaults to true (certificates volume and volumeMounts are added) when unset,
-  # for backwards compatibility. Set to false to omit them entirely, e.g. when TLS
-  # termination happens outside the pod.
+  # for backwards compatibility. Set to false to omit them, e.g. when the TLS cert
+  # and key files are mounted by other means, such as a CSI driver using
+  # extraVolumes/extraVolumeMounts.
   # enabled: true
   certificateSecret: terraform-enterprise-certificates
   caCertBaseDir: /etc/ssl/certs

--- a/values.yaml
+++ b/values.yaml
@@ -60,6 +60,10 @@ resources:
 # to unauthorized users. It is recommended to manage secrets through a secure
 # secrets management system. The values given below are for testing purposes only.
 tls:
+  # Defaults to true (certificates volume and volumeMounts are added) when unset,
+  # for backwards compatibility. Set to false to omit them entirely, e.g. when TLS
+  # termination happens outside the pod.
+  # enabled: true
   certificateSecret: terraform-enterprise-certificates
   caCertBaseDir: /etc/ssl/certs
   caCertFileName: custom_ca_certs.pem


### PR DESCRIPTION
CHANGELOG:

* Add optional `tls.enabled` value to omit the chart-managed certificates volume and volumeMounts, for use with externally mounted TLS files (e.g. Secrets Store CSI). Defaults to true; existing behavior is unchanged.

## Summary

Adds a `tls.enabled` value that makes the chart-managed TLS secret volume and its cert/key volumeMounts optional. When unset or `true` (the default), rendered output is identical to today. When explicitly `false`, the `certificates` volume and mounts are omitted from the Deployment.

## Background

The chart already supports configuring the TLS file paths used by TFE, but it always renders the certificates secret volume and corresponding mounts. That prevents clean use of externally mounted TLS files when those files must exist at the same paths.

Our concrete case: we use the Azure Key Vault Secrets Store CSI driver to mount the TLS cert/key as files, via `extraVolumes` with a `csi` volume source. Passing the values through a Kubernetes Secret instead does not work for us — the secret content is fetched after the container starts and is not available at the configured path when Terraform Enterprise reads it, so TFE errors out at startup. Mounting the CSI files at the chart's TLS paths collides with the chart-managed mounts:

    spec.template.spec.containers[0].volumeMounts[4].mountPath: Invalid value: "/etc/ssl/private/terraform-enterprise/cert.pem": must be unique
    spec.template.spec.containers[0].volumeMounts[5].mountPath: Invalid value: "/etc/ssl/private/terraform-enterprise/key.pem": must be unique

Today we work around this with a postrender step that strips the chart-managed mounts, which is brittle. This PR adds a supported switch instead, following the optional-volume pattern used for `tlsSecondary` (#129) and building on the `extraVolumes`/`extraVolumeMounts` support added in #112.

## Helm Chart Impact

Architecture impact:

None. No new resources or templates; two existing blocks in deployment.yaml (the `certificates` volume and its volumeMounts) are gated behind a conditional.

Rendered resource / operational / security impact:

- Default (`tls.enabled` unset or `true`): rendered output is byte-for-byte identical to the current chart, verified via `helm template` diff.
- `tls.enabled=false`: the `certificates` volume and its cert/key mounts are omitted from the Deployment. Operators opting in are responsible for providing TLS material at `tls.certMountPath`/`tls.keyMountPath` by other means (e.g. CSI driver via `extraVolumes`/`extraVolumeMounts`). TFE itself still requires those files, so this does not disable TLS — it only changes how the files arrive in the pod.
- No changes to RBAC, ingress, storage, or the Secret resources themselves (the `terraform-enterprise-certificates` Secret is still created when `certData`/`keyData` are provided).

## Testing

- `helm lint .` — passes
- `helm template . | kubeconform -strict` — 8/8 resources valid for all three cases (`tls.enabled` unset, `true`, and `false`)
- `helm template` with `tls.enabled` unset — output diffed byte-for-byte identical to pre-change rendering
- `helm template --set tls.enabled=true` — identical to unset
- `helm template --set tls.enabled=false` — certificates volume and both mounts cleanly omitted; no orphaned mount references
- Real-world validation: without this change, adding our Key Vault CSI mounts at the chart's TLS paths fails at deploy time with:

      spec.template.spec.containers[0].volumeMounts[4].mountPath: Invalid value: "/etc/ssl/private/terraform-enterprise/cert.pem": must be unique
      spec.template.spec.containers[0].volumeMounts[5].mountPath: Invalid value: "/etc/ssl/private/terraform-enterprise/key.pem": must be unique
      failed to create resource

  We currently run TFE successfully using CSI mounts plus a postrender that removes the chart-managed mounts — the behavior this flag replaces.

## Reviewer Notes

- The condition is `ne .Values.tls.enabled false` rather than a plain truthiness check, so an unset key (nil) defaults to enabled. Existing values files need no changes.
- `values.yaml` documents `enabled` as a commented-out key rather than an explicit `enabled: true`, deliberately: users on older values files won't have the key, and nil must mean "enabled."
- Non-goal: this doesn't change Secret creation. With `tls.enabled=false`, the certificates Secret is still rendered if `certData`/`keyData` are set — it's just not mounted.
- Revert plan: reverting this PR fully restores prior behavior; no data or state migration is involved since the default renders identical output.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.