### PR TITLE
Backports: Add configurable readiness probe timing (#180)

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -148,6 +148,18 @@ spec:
             path: {{ .Values.tfe.readinessProbePath | default "/api/v1/health/readiness" }}
             port: {{ .Values.tfe.privateHttpPort }}
             scheme: {{ .Values.tfe.readinessProbeScheme | default "HTTP"  }}
+          {{- if .Values.tfe.readinessProbeInitialDelaySeconds }}
+          initialDelaySeconds: {{ .Values.tfe.readinessProbeInitialDelaySeconds }}
+          {{- end }}
+          {{- if .Values.tfe.readinessProbePeriodSeconds }}
+          periodSeconds: {{ .Values.tfe.readinessProbePeriodSeconds }}
+          {{- end }}
+          {{- if .Values.tfe.readinessProbeFailureThreshold }}
+          failureThreshold: {{ .Values.tfe.readinessProbeFailureThreshold }}
+          {{- end }}
+          {{- if .Values.tfe.readinessProbeTimeoutSeconds }}
+          timeoutSeconds: {{ .Values.tfe.readinessProbeTimeoutSeconds }}
+          {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:

--- a/values.yaml
+++ b/values.yaml
@@ -106,6 +106,10 @@ tfe:
   ## Readiness probe settings customize the terraform-enterprise health check path, eg: to use the full service dependency check
   # readinessProbePath: "/_health_check?full"
   # readinessProbeScheme: "HTTP"
+  # readinessProbeInitialDelaySeconds: 60
+  # readinessProbePeriodSeconds: 10
+  # readinessProbeFailureThreshold: 30
+  # readinessProbeTimeoutSeconds: 5
 
 # nodeSelector labels for server pod assignment, formatted as a multi-line string or YAML map.
 nodeSelector: {}


### PR DESCRIPTION
CHANGELOG: Adds configurable readiness probe timing for environments that need it.

<!--  Please add a changelog entry that will be used for our release notes, or add "no-impact". -->

## Summary

<!-- What changed in 1-3 sentences? -->
This change backports #180 into the 2.0.x patch line.

## Background

<!-- Why is this change needed? Link issues, incidents, or prior PRs if helpful. -->
See #180 


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
