### PR TITLE
Add Admin Console access-mode chart value [TF-38319]

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,11 @@ jobs:
         run: |
           helm lint .
 
+      # Step 3b: Template coverage for the Admin Console access-mode truth table.
+      - name: Test Admin Console access mode
+        run: |
+          ./ci/test-admin-console-access-mode.sh .
+
       # Step 4: Install kubeconform
       - name: Install kubeconform
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-* Add `tfe.adminConsole.accessMode` to configure the Admin Console access posture (`TFE_ADMIN_CONSOLE_ACCESS_MODE`: `port`, `both`, `disabled`) without injecting raw environment variables. Omitting it preserves the legacy dedicated-port behaviour. In `both` mode the default ingress already routes `/platform/admin` to the service.
+* Add `tfe.adminConsole.accessMode` to configure the Admin Console access posture (`TFE_ADMIN_CONSOLE_ACCESS_MODE`: `port`, `both`, `disabled`) without injecting raw environment variables. Omitting it preserves the legacy dedicated-port behaviour. In `both` mode the default ingress already routes `/platform/admin` to the service. See the security note in `docs/configuration.md`: `both` exposes the privileged admin surface on the primary hostname with no network restriction, so restrict it at the ingress and/or via `TFE_ADMIN_CONSOLE_STANDARD_ALLOW_CIDRS`/`TFE_ADMIN_CONSOLE_STANDARD_TRUSTED_PROXIES`.
 
 ## 1.1.1 (December 5th, 2023)
 * Support container securityContext configuration from values [#57](https://github.com/hashicorp/terraform-enterprise-helm/pull/57) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Add `tfe.adminConsole.accessMode` to configure the Admin Console access posture (`TFE_ADMIN_CONSOLE_ACCESS_MODE`: `port`, `both`, `disabled`) without injecting raw environment variables. Omitting it preserves the legacy dedicated-port behaviour. In `both` mode the default ingress already routes `/platform/admin` to the service.
+
 ## 1.1.1 (December 5th, 2023)
 * Support container securityContext configuration from values [#57](https://github.com/hashicorp/terraform-enterprise-helm/pull/57) 
 

--- a/ci/test-admin-console-access-mode.sh
+++ b/ci/test-admin-console-access-mode.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copyright IBM Corp. 2026
+# SPDX-License-Identifier: MPL-2.0
+#
+# Template coverage for the Admin Console access mode (TF-38319).
+#
+# Renders the chart across the access-mode truth table and asserts the ConfigMap
+# TFE_ADMIN_CONSOLE_ACCESS_MODE value matches, that omitting the value preserves
+# the legacy unset behaviour (key absent), and that an unsupported value fails
+# rendering. Dependency-free: needs only `helm`.
+
+set -euo pipefail
+
+CHART_DIR="${1:-.}"
+KEY="TFE_ADMIN_CONSOLE_ACCESS_MODE"
+failures=0
+
+render() {
+  # Prints the rendered ConfigMap access-mode line, if any.
+  helm template "$CHART_DIR" "$@" 2>/dev/null | grep "$KEY" || true
+}
+
+expect_value() {
+  local mode="$1" expected="  $KEY: \"$1\""
+  local got
+  got="$(render --set "tfe.adminConsole.accessMode=$mode")"
+  if [[ "$got" == "$expected" ]]; then
+    echo "PASS: accessMode=$mode renders $KEY=\"$mode\""
+  else
+    echo "FAIL: accessMode=$mode rendered [$got], expected [$expected]"
+    failures=$((failures + 1))
+  fi
+}
+
+# port / both / disabled must each render their value verbatim.
+expect_value port
+expect_value both
+expect_value disabled
+
+# Omitting the value (unset) must not render the key, preserving legacy behaviour.
+if [[ -z "$(render)" ]]; then
+  echo "PASS: unset accessMode omits $KEY (legacy default preserved)"
+else
+  echo "FAIL: unset accessMode should omit $KEY"
+  failures=$((failures + 1))
+fi
+
+# An unsupported value must fail rendering rather than pass an invalid mode
+# through to the container.
+if helm template "$CHART_DIR" --set tfe.adminConsole.accessMode=enabled >/dev/null 2>&1; then
+  echo "FAIL: unsupported accessMode=enabled should fail rendering"
+  failures=$((failures + 1))
+else
+  echo "PASS: unsupported accessMode=enabled fails rendering"
+fi
+
+if [[ "$failures" -ne 0 ]]; then
+  echo "$failures assertion(s) failed"
+  exit 1
+fi
+echo "All Admin Console access-mode assertions passed"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,10 +101,34 @@ primary host to the Terraform Enterprise service (a `/` `Prefix` rule), so
 `/platform/admin/` is reachable without configuring a separate Admin Console
 ingress.
 
+> **Security — `both` exposes the privileged admin surface with no network
+> restriction.** Because the default ingress routes every path to the TFE
+> service, enabling `both` publishes the privileged Admin Console UI and Admin
+> API on your primary hostname to anything that can reach the ingress. If you
+> previously isolated the dedicated admin port with a firewall or
+> `NetworkPolicy`, that protection no longer applies. A Kubernetes
+> `NetworkPolicy` operates at L3/L4 and **cannot** restrict by URL path, so it
+> cannot protect `/platform/admin` while keeping the rest of `:443` open — the
+> restriction must be applied at the ingress/HTTP layer. Before enabling `both`:
+>
+> - restrict `/platform/admin` at the ingress controller (for example, an IP
+>   allow-list annotation scoped to that path), and/or
+> - set the TFE-side allow-list via `env.variables`:
+>   `TFE_ADMIN_CONSOLE_STANDARD_ALLOW_CIDRS` (permitted client sources) together
+>   with `TFE_ADMIN_CONSOLE_STANDARD_TRUSTED_PROXIES` (your ingress/LB addresses,
+>   required so the allow-list matches the real client rather than the ingress).
+
 ```yaml
 tfe:
   adminConsole:
     accessMode: both
+env:
+  variables:
+    # Restore a network restriction on the shared :443 admin surface. Trusted
+    # proxies are required behind an ingress so the allow-list matches the
+    # client, not the ingress source address.
+    TFE_ADMIN_CONSOLE_STANDARD_ALLOW_CIDRS: "10.20.0.0/16"
+    TFE_ADMIN_CONSOLE_STANDARD_TRUSTED_PROXIES: "192.0.2.0/24"
 ```
 
 ## Custom agent worker pod template

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,36 @@ items:
 ...
 ```
 
+## Admin Console access mode
+
+The `.Values.tfe.adminConsole.accessMode` value sets the Admin Console access
+posture by rendering `TFE_ADMIN_CONSOLE_ACCESS_MODE` into the application
+ConfigMap. Supported values are `port`, `both`, and `disabled`. Omitting the
+value (the default empty string) preserves the legacy behaviour, in which the
+Admin Console is served on the dedicated admin HTTPS port only.
+
+| `accessMode`   | Dedicated admin port (`tfe.adminHttpsPort`) | Primary hostname `/platform/admin` |
+| -------------- | ------------------------------------------- | ---------------------------------- |
+| `port`         | UI + API                                    | off                                |
+| `both`         | UI + API                                    | UI + API                           |
+| `disabled`     | off                                         | off                                |
+| _unset_ (`""`) | legacy: UI + API                            | off                                |
+
+Any value other than `port`, `both`, `disabled`, or empty fails chart rendering
+with an actionable error.
+
+In `both` mode the Admin Console is served at `/platform/admin` on the primary
+hostname over standard HTTPS. The default ingress routes all paths on the
+primary host to the Terraform Enterprise service (a `/` `Prefix` rule), so
+`/platform/admin/` is reachable without configuring a separate Admin Console
+ingress.
+
+```yaml
+tfe:
+  adminConsole:
+    accessMode: both
+```
+
 ## Custom agent worker pod template
 
 Terraform Enterprise now supports the inclusion of a custom pod template via `agentWorkerPodTemplate` in the Values file.

--- a/templates/config-map.yaml
+++ b/templates/config-map.yaml
@@ -19,6 +19,12 @@ data:
   TFE_HTTP_PORT: "{{ .Values.tfe.privateHttpPort }}"
   TFE_HTTPS_PORT: "{{ .Values.tfe.privateHttpsPort }}"
   TFE_ADMIN_HTTPS_PORT: "{{ .Values.tfe.adminHttpsPort }}"
+  {{- with .Values.tfe.adminConsole.accessMode }}
+  {{- if not (has . (list "port" "both" "disabled")) }}
+  {{- fail (printf "tfe.adminConsole.accessMode must be one of \"port\", \"both\", \"disabled\" (or empty to keep the legacy default); got %q" .) }}
+  {{- end }}
+  TFE_ADMIN_CONSOLE_ACCESS_MODE: "{{ . }}"
+  {{- end }}
   {{- if or (and .Values.tlsSecondary.certData .Values.tlsSecondary.keyData) .Values.tlsSecondary.certificateSecret }}
   TFE_TLS_CERT_FILE_SECONDARY: "{{ .Values.tlsSecondary.certMountPath }}"
   TFE_TLS_KEY_FILE_SECONDARY:  "{{ .Values.tlsSecondary.keyMountPath }}"

--- a/values.yaml
+++ b/values.yaml
@@ -103,6 +103,24 @@ tfe:
   privateHttpsPort: 8443
   # Specifies the port that the system API endpoints listen on for HTTPS requests.
   adminHttpsPort: 8446
+  # Admin Console access posture. Renders TFE_ADMIN_CONSOLE_ACCESS_MODE.
+  #
+  # Supported values (access-mode truth table):
+  #
+  #   accessMode   dedicated :adminHttpsPort   primary host /platform/admin
+  #   ----------   -------------------------   ----------------------------
+  #   "port"       UI + API                    off
+  #   "both"       UI + API                    UI + API
+  #   "disabled"   off                         off
+  #   "" (unset)   legacy: UI + API            off
+  #
+  # Leave empty ("") to preserve the legacy behaviour (dedicated port only). Any
+  # other value fails template rendering. In "both" mode the Admin Console is
+  # served at /platform/admin on the primary hostname, which the default ingress
+  # (a `/` Prefix rule) already routes to the TFE service - no separate Admin
+  # Console ingress is required.
+  adminConsole:
+    accessMode: ""
   ## Readiness probe settings customize the terraform-enterprise health check path, eg: to use the full service dependency check
   # readinessProbePath: "/_health_check?full"
   # readinessProbeScheme: "HTTP"

--- a/values.yaml
+++ b/values.yaml
@@ -119,6 +119,20 @@ tfe:
   # served at /platform/admin on the primary hostname, which the default ingress
   # (a `/` Prefix rule) already routes to the TFE service - no separate Admin
   # Console ingress is required.
+  #
+  # SECURITY: "both" serves the privileged Admin Console UI and Admin API on your
+  # primary hostname over standard HTTPS, alongside the dedicated admin port.
+  # Because the default ingress routes all paths to the TFE service, enabling
+  # "both" publishes the admin surface to anything that can reach the ingress,
+  # with NO network restriction. If you previously relied on firewalling /
+  # NetworkPolicy on the dedicated admin port, that isolation no longer applies.
+  # A Kubernetes NetworkPolicy cannot restrict by URL path, so it cannot protect
+  # /platform/admin while leaving the rest of :443 open. Before enabling "both",
+  # restrict access at the ingress layer (e.g. ingress-controller IP allow-list
+  # annotations on the /platform/admin path) and/or set the TFE-side allow-list
+  # env vars TFE_ADMIN_CONSOLE_STANDARD_ALLOW_CIDRS and
+  # TFE_ADMIN_CONSOLE_STANDARD_TRUSTED_PROXIES (via env.variables; the latter is
+  # required so the allow-list matches the real client rather than the ingress).
   adminConsole:
     accessMode: ""
   ## Readiness probe settings customize the terraform-enterprise health check path, eg: to use the full service dependency check


### PR DESCRIPTION
## What

Adds `tfe.adminConsole.accessMode` — a first-class chart value for the Admin Console access posture — so Helm operators no longer have to inject a raw `TFE_ADMIN_CONSOLE_ACCESS_MODE` environment variable via `env.variables`.

## Behaviour (access-mode truth table)

| `accessMode`   | Dedicated admin port | Primary host `/platform/admin` |
| -------------- | -------------------- | ------------------------------ |
| `port`         | UI + API             | off                            |
| `both`         | UI + API             | UI + API                       |
| `disabled`     | off                  | off                            |
| _unset_ (`""`) | legacy: UI + API     | off                            |

- Omitting the value preserves the legacy behaviour (dedicated admin port only).
- Unsupported values fail chart rendering with an actionable error.
- In `both` mode the Admin Console is served at `/platform/admin` on the primary hostname. The default ingress (`/` `Prefix`) already routes it to the TFE service — **no separate Admin Console ingress required**.

## How

- `values.yaml`: new `tfe.adminConsole.accessMode` with the truth table documented inline.
- `templates/config-map.yaml`: renders `TFE_ADMIN_CONSOLE_ACCESS_MODE` when set; omits it when empty; `fail`s on unsupported values.
- `ci/test-admin-console-access-mode.sh`: dependency-free template-coverage test (needs only `helm`), wired into the existing Helm Chart CI workflow.
- `docs/configuration.md`: access-mode section + ingress note.

## Tests

- `helm lint .` clean.
- `./ci/test-admin-console-access-mode.sh .` — all truth-table + invalid-value assertions pass.

## Context

Part of the "Admin Console on standard HTTPS port" initiative (TFE epic TF-37785). This is the Helm counterpart to the TFE-side access-mode work (TFE PR #4905). It is independent of that PR and targets `main` here.

## Jira

TF-38319 (not transitioned — implementation only)
