### PR TITLE
Pre-publish changes for the 2.0.4 chart release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.4 (July 17th, 2025)
+* Support custom configuration for readiness probe timing [#180](https://github.com/hashicorp/terraform-enterprise-helm/pull/180)
+
 ## 1.1.1 (December 5th, 2023)
 * Support container securityContext configuration from values [#57](https://github.com/hashicorp/terraform-enterprise-helm/pull/57) 
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 1.6.9
+version: 2.0.4
 appVersion: "2.0.4"


### PR DESCRIPTION
CHANGELOG: Support custom configuration for readiness probe timing [#180](https://github.com/hashicorp/terraform-enterprise-helm/pull/180)

<!--  Please add a changelog entry that will be used for our release notes, or add "no-impact". -->

## Summary

<!-- What changed in 1-3 sentences? -->
This update introduces configuration changes necessary to release the `release/2.0.x` branch as version v2.0.4.

## Background

<!-- Why is this change needed? Link issues, incidents, or prior PRs if helpful. -->
These changes enable a standard chart release for the 2.0.x branch.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
