### PR TITLE
security: pin GitHub Actions to full commit SHAs (SECVULN-50778, SECV…

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       # Step 1: Checkout the repository
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       # Step 2: Set up Helm
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
 
       # Step 3: Lint the Helm chart
       - name: Lint Helm chart


### PR DESCRIPTION

CHANGELOG: no-impact

## Summary

This PR updates the `.github/workflows/check.yml` workflow to pin `actions/checkout` and `azure/setup-helm` to their full commit SHAs instead of mutable version tags. This is a security hardening measure with no functional change to the workflow behavior.

Addresses: [SECVULN-50779](https://hashicorp.atlassian.net/browse/SECVULN-50779) and [SECVULN-50778](https://hashicorp.atlassian.net/browse/SECVULN-50778)

## Background

Mutable tags (e.g., `@v3`) in GitHub Actions can be silently redirected to different commits, creating a supply chain attack vector. Pinning to immutable commit SHAs ensures the exact, audited version of each action is used every run, regardless of any upstream tag changes. This aligns with security best practices (e.g., [StepSecurity](https://docs.stepsecurity.io/), OpenSSF Scorecard recommendations).

## Helm Chart Impact

Architecture impact:
No change to the Helm chart architecture. This PR only modifies CI workflow configuration.

Rendered resource / operational / security impact:
No impact on rendered Kubernetes resources, chart defaults, upgrade/rollback behavior, RBAC, secrets, ingress/networking, storage, or availability. The change is limited to CI tooling and improves the security posture of the GitHub Actions pipeline by preventing potential tag-hijacking attacks.

## Testing

The workflow behavior is unchanged — only the action references have been pinned. The existing `helm lint` step will continue to execute as before.

Suggested validation:
- Confirm the pinned SHAs correspond to the expected versions:
  - `actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26` → v3.7.0 ✅
  - `azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78` → v3.5 ✅
- Trigger the `check.yml` workflow manually or via a test PR to confirm CI passes as expected.

## Reviewer Notes

- This is a **non-functional, security-only change**. No chart logic, templates, or values are modified.
- The inline comments (`# v3.7.0`, `# v3.5`) are intentionally preserved to make the pinned SHA human-readable and auditable.
- Follow-up work could include automating SHA pinning updates via a tool like [Dependabot for Actions](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem) or [StepSecurity's Harden Runner](https://github.com/step-security/harden-runner).

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
  > Revert is trivial — simply re-open or revert this PR to restore the mutable tag references.

- [x] If applicable, I've documented the impact of any changes to security controls.
  > This change **improves** security controls by replacing mutable action tags with immutable commit SHA pins, reducing the risk of a compromised or hijacked upstream action tag affecting this CI pipeline.
  
  Jira: https://hashicorp.atlassian.net/browse/TF-39813

[SECVULN-50779]: https://hashicorp.atlassian.net/browse/SECVULN-50779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SECVULN-50778]: https://hashicorp.atlassian.net/browse/SECVULN-50778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ