### PR TITLE
TF-40321: Update Chart.yaml version to 2.0.6 for TFE 2.0.6 release

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2023, 2025
+# Copyright IBM Corp. 2023, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 apiVersion: v2

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 2.0.5
-appVersion: "2.0.5"
+version: 2.0.6
+appVersion: "2.0.6"


### PR DESCRIPTION
CHANGELOG: no-impact

## Summary
Bumps `version` and `appVersion` in Chart.yaml from `2.0.5` to `2.0.6` in preparation for the TFE 2.0.6 release.

## Background
Per the release process, every TFE release requires a corresponding Helm chart release on the matching release branch. This updates the chart to signal compatibility with TFE 2.0.6. Jira: [TF-40321.](https://hashicorp.atlassian.net/browse/TF-40321)

## Helm Chart Impact

Architecture impact:
None.

Rendered resource / operational / security impact:
None. This is a version bump only. No Kubernetes resources, defaults, or security-sensitive areas are affected.

## Testing
No functional changes. Verified Chart.yaml values are correct.

## Reviewer Notes
This PR only changes version numbers. The tag and publish step will be run at release time next week via the "Create or Update Tag" workflow.

## PCI review checklist

- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.