### PR TITLE
TF-40321: Update Chart.yaml version to 2.0.6 for TFE 2.0.6 release

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2023, 2025
+# Copyright IBM Corp. 2023, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 apiVersion: v2

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2023, 2026
+# Copyright IBM Corp. 2023, 2025
 # SPDX-License-Identifier: MPL-2.0
 
 apiVersion: v2
@@ -6,5 +6,5 @@ name: terraform-enterprise
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Terraform-Enterprise Chart
 type: application
-version: 1.6.8
-appVersion: "2.0.4"
+version: 2.0.6
+appVersion: "2.0.6"


### PR DESCRIPTION
CHANGELOG: no-impact

## Summary
Bumps `version` and `appVersion` in Chart.yaml from `1.6.8`/`2.0.4` to `2.0.6`/`2.0.6` on main, syncing it with the release/2.0.x branch in preparation for the TFE 2.0.6 release.

## Background
Per the release process, every TFE release requires a corresponding Helm chart release on the matching release branch. This PR syncs main to match what is already merged on release/2.0.x (PR #217). Jira: TF-40321.

## Helm Chart Impact

Architecture impact:
None.

Rendered resource / operational / security impact:
None. This is a version bump only. No Kubernetes resources, defaults, or security-sensitive areas are affected.

## Testing
No functional changes. Verified Chart.yaml values are correct.

## Reviewer Notes
This is the main-branch sync for the same change in PR #217 (release/2.0.x). The tag and publish step will be run at release time next week via the Create or Update Tag workflow.

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I have documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I have documented the impact of any changes to security controls.